### PR TITLE
feat: support general users view and cancel own tasks

### DIFF
--- a/src/pages/manage/sidemenu_items.tsx
+++ b/src/pages/manage/sidemenu_items.tsx
@@ -96,11 +96,13 @@ export const side_menu_items: SideMenuItem[] = [
     title: "manage.sidemenu.tasks",
     icon: OcWorkflow2,
     to: "/@manage/tasks",
+    role: UserRole.GENERAL,
     children: [
       {
         title: "manage.sidemenu.offline_download",
         icon: IoMagnetOutline,
         to: "/@manage/tasks/aria2",
+        role: UserRole.GENERAL,
         component: lazy(() => import("./tasks/offline_download")),
       },
       // {
@@ -119,12 +121,14 @@ export const side_menu_items: SideMenuItem[] = [
         title: "manage.sidemenu.upload",
         icon: BsCloudUploadFill,
         to: "/@manage/tasks/upload",
+        role: UserRole.GENERAL,
         component: lazy(() => import("./tasks/Upload")),
       },
       {
         title: "manage.sidemenu.copy",
         icon: IoCopy,
         to: "/@manage/tasks/copy",
+        role: UserRole.GENERAL,
         component: lazy(() => import("./tasks/Copy")),
       },
     ],

--- a/src/pages/manage/tasks/Task.tsx
+++ b/src/pages/manage/tasks/Task.tsx
@@ -43,6 +43,13 @@ const StateMap: Record<
   [TaskStateEnum.Succeeded]: "success",
   [TaskStateEnum.Canceled]: "neutral",
 }
+
+const Creator = (props: { name: string; role: number }) => {
+  if (props.role < 0) return null
+  const roleColors = ["info", "neutral", "accent"]
+  return <Badge colorScheme={roleColors[props.role] as any}>{props.name}</Badge>
+}
+
 export const TaskState = (props: { state: number }) => {
   const t = useT()
   return (
@@ -58,10 +65,10 @@ export const Task = (props: TaskInfo & TasksProps) => {
   const canRetry = props.done === "done" && props.state === TaskStateEnum.Failed
   const [operateLoading, operate] = useFetch(
     (): PEmptyResp =>
-      r.post(`/admin/task/${props.type}/${operateName}?tid=${props.id}`),
+      r.post(`/task/${props.type}/${operateName}?tid=${props.id}`),
   )
   const [retryLoading, retry] = useFetch(
-    (): PEmptyResp => r.post(`/admin/task/${props.type}/retry?tid=${props.id}`),
+    (): PEmptyResp => r.post(`/task/${props.type}/retry?tid=${props.id}`),
   )
   const [deleted, setDeleted] = createSignal(false)
   return (
@@ -85,6 +92,7 @@ export const Task = (props: TaskInfo & TasksProps) => {
           >
             {props.name}
           </Heading>
+          <Creator name={props.creator} role={props.creator_role} />
           <TaskState state={props.state} />
           <Text
             css={{

--- a/src/pages/manage/tasks/Tasks.tsx
+++ b/src/pages/manage/tasks/Tasks.tsx
@@ -14,7 +14,7 @@ export interface TasksProps {
 export const Tasks = (props: TasksProps) => {
   const t = useT()
   const [loading, get] = useFetch(
-    (): PResp<TaskInfo[]> => r.get(`/admin/task/${props.type}/${props.done}`),
+    (): PResp<TaskInfo[]> => r.get(`/task/${props.type}/${props.done}`),
   )
   const [tasks, setTasks] = createSignal<TaskInfo[]>([])
   const refresh = async () => {
@@ -36,13 +36,13 @@ export const Tasks = (props: TasksProps) => {
     onCleanup(() => clearInterval(interval))
   }
   const [clearDoneLoading, clearDone] = useFetch(
-    (): PEmptyResp => r.post(`/admin/task/${props.type}/clear_done`),
+    (): PEmptyResp => r.post(`/task/${props.type}/clear_done`),
   )
   const [clearSucceededLoading, clearSucceeded] = useFetch(
-    (): PEmptyResp => r.post(`/admin/task/${props.type}/clear_succeeded`),
+    (): PEmptyResp => r.post(`/task/${props.type}/clear_succeeded`),
   )
   const [retryFailedLoading, retryFailed] = useFetch(
-    (): PEmptyResp => r.post(`/admin/task/${props.type}/retry_failed`),
+    (): PEmptyResp => r.post(`/task/${props.type}/retry_failed`),
   )
   const [page, setPage] = createSignal(1)
   const pageSize = 20

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,6 +1,8 @@
 export interface TaskInfo {
   id: string
   name: string
+  creator: string
+  creator_role: number
   state: number
   status: string
   progress: number


### PR DESCRIPTION
This pull request is the frontend part of AlistGo/alist/#7398

1. Add a creator attribute to the upload, copy and offline download tasks, so that a GENERAL task creator can view and cancel them. The creator will be displayed over the task state in the form of a Badge.
2. Transfer call on `/admin/task` to `/task`.