### PR TITLE
fix: Markdown base64编码图片支持

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -186,7 +186,7 @@ export function Markdown(props: {
       let url = match.match(/!\[.*?\]\((.*?)\)/)![1]
       // 检查是否为 base64 编码的图片
       if (url.startsWith("data:image/")) {
-          return match;  // 如果是 base64 编码的图片，直接返回原标签
+        return match // 如果是 base64 编码的图片，直接返回原标签
       }
       if (
         url.startsWith("http://") ||

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -184,6 +184,10 @@ export function Markdown(props: {
     content = content.replace(/!\[.*?\]\((.*?)\)/g, (match) => {
       const name = match.match(/!\[(.*?)\]\(.*?\)/)![1]
       let url = match.match(/!\[.*?\]\((.*?)\)/)![1]
+      // 检查是否为 base64 编码的图片
+      if (url.startsWith("data:image/")) {
+          return match;  // 如果是 base64 编码的图片，直接返回原标签
+      }
       if (
         url.startsWith("http://") ||
         url.startsWith("https://") ||


### PR DESCRIPTION
修复Markdown中内置base64编码图片的解析错误问题

老版本是支持的，新版本增加对直链的支持后，导致base64编码图片解析出错。

<img width="971" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/49ceca64-f142-4b27-b8f9-e33c6c07de04">


不支持的Markdown文件特征如下：
<img width="693" alt="image" src="https://github.com/user-attachments/assets/f733bb53-0248-4ed1-9021-7a613b6c8f87">
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/687e6629-4498-468e-9db3-618846588144">
<img width="679" alt="image" src="https://github.com/user-attachments/assets/a5d42aa8-2eb5-4125-b9b3-234470db3109">

