### PR TITLE
fix: add z-index to context menu

### DIFF
--- a/src/pages/home/folder/context-menu.tsx
+++ b/src/pages/home/folder/context-menu.tsx
@@ -40,6 +40,7 @@ export const ContextMenu = () => {
       id={1}
       animation="scale"
       theme={colorMode() !== "dark" ? "light" : "dark"}
+      style="z-index: var(--hope-zIndices-popover)"
     >
       <For each={["rename", "move", "copy", "delete"]}>
         {(name) => (


### PR DESCRIPTION
add z-index to the context menu to avoid being obstructed by the nav bar
为右键菜单添加额外的z-index来避免导航栏的遮挡

reason：
When the "position of header & nav bar" option is set to anything other than normal, the nav bar will overlay the context menu.
原因：设置“标题栏和导航栏的位置”为除了“普通”以外的选项时, 导航栏会遮挡右键菜单

Any suggestions are appreciated.
第一个pr，有问题还请大神指点。

<img width="234" alt="1" src="https://github.com/user-attachments/assets/bacc1d77-079c-498f-bbad-250a560fa381" />

<img width="359" alt="2" src="https://github.com/user-attachments/assets/c87e88c1-b0ab-4ceb-bf7a-ced87da80b27" />


