### PR TITLE
feat: markdown mermaid support

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -162,6 +162,13 @@ const insertKatexCSS = once(() => {
   document.head.appendChild(link)
 })
 
+const insertMermaidJS = once(() => {
+  const script = document.createElement("script")
+  script.src =
+    "https://registry.npmmirror.com/mermaid/11/files/dist/mermaid.min.js"
+  document.body.appendChild(script)
+})
+
 export function Markdown(props: {
   children?: string | ArrayBuffer
   class?: string
@@ -213,9 +220,14 @@ export function Markdown(props: {
     on(md, () => {
       setShow(false)
       insertKatexCSS()
+      insertMermaidJS()
       setTimeout(() => {
         setShow(true)
         hljs.highlightAll()
+        window.mermaid &&
+          window.mermaid.run({
+            querySelector: ".language-mermaid",
+          })
         window.onMDRender && window.onMDRender()
       })
     }),


### PR DESCRIPTION
在 Markdown 预览中添加 Mermaid 图表支持

目前 `solid-markdown` 渲染代码块中的 mermaid 的结果如下：

```html
<pre key="pre-75-1-38"><code class="language-mermaid" key="code-75-1-0">flowchart TD
    A[Christmas] --&gt;|Get money| B(Go shopping)
    B --&gt; C{Let me think}
    C --&gt;|One| D[Laptop]
    C --&gt;|Two| E[iPhone]
    C --&gt;|Three| F[fa:fa-car Car]
  
</code></pre>
```

通过 CDN 引入 mermaid  js，使用 `mermaid.run()` 对 `language-mermaid` 执行渲染

官方文档参考: <https://mermaid.js.org/config/usage.html>

为避免增加项目的构建体积，此处选择通过 CDN 来引入 Mermaid.js 库，而不是通过 NPM 包管理器安装（会给 dist 增加 3-5 MB 的体积）

如果存在任何潜在的问题或改进建议，请随时提出讨论