### PR TITLE
chore: ignore case when sort

### DIFF
--- a/src/store/obj.ts
+++ b/src/store/obj.ts
@@ -95,6 +95,7 @@ export type OrderBy = "name" | "size" | "modified"
 
 export const sortObjs = (orderBy: OrderBy, reverse?: boolean) => {
   log("sort:", orderBy, reverse)
+  naturalSort.insensitive = true;
   setObjStore(
     "objs",
     produce((objs) =>


### PR DESCRIPTION
By default, `naturalSort` sort strings with case sensitive, which means A-Za-z.
This change aligns the sort behavior with Linux and Windows, which is Aa-Zz.