### PR TITLE
feat(index): add `disable index` option for storages

### DIFF
--- a/src/lang/en/storages.json
+++ b/src/lang/en/storages.json
@@ -35,7 +35,8 @@
       "front": "Extract to front",
       "back": "Extract to back"
     },
-    "enable_sign": "Enable sign"
+    "enable_sign": "Enable sign",
+    "disable_index": "Disable index"
   },
   "other": {
     "start_load_success": "Start loading",


### PR DESCRIPTION
Front-end part of: https://github.com/AlistGo/alist/pull/7730

Allow users to disable storage indexing.
允许用户禁用存储索引。

<img width="148" alt="image" src="https://github.com/user-attachments/assets/727abe8d-7a39-4f8b-a865-77604f46917e" />
