### PR TITLE
fix(web): cancel video loading after leaving the video page

### DIFF
--- a/src/pages/home/previews/video.tsx
+++ b/src/pages/home/previews/video.tsx
@@ -310,6 +310,7 @@ const Preview = () => {
     })
   })
   onCleanup(() => {
+    if (player && player.video) player.video.src = ""
     player?.destroy()
   })
   const [autoNext, setAutoNext] = createSignal()


### PR DESCRIPTION
The video continues loading even after leaving the video page, set the `src` attribute to an empty string to stop loading process.

离开视频页面后视频请求仍会继续加载占用带宽，把 `src` 属性设置为空字符串来停止加载。