### PR TITLE
fix(pagination): fix incorrect pagination after refreshing

### DIFF
--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -6,6 +6,7 @@ import {
   State,
   getPagination,
   objStore,
+  recordScroll,
   recoverScroll,
   me,
 } from "~/store"
@@ -192,9 +193,7 @@ export const usePath = () => {
         ObjStore.setWrite(data.write)
         ObjStore.setProvider(data.provider)
         ObjStore.setState(State.Folder)
-        if (!(append && (index ?? 1) > 1)) {
-          recoverScroll(path)
-        }
+        recoverScroll(path)
       },
       handleErr,
     )
@@ -222,6 +221,13 @@ export const usePath = () => {
     handlePathChange: handlePathChange,
     setPathAs: setPathAs,
     refresh: (retry_pass?: boolean, force?: boolean) => {
+      if (
+        pagination.type === "load_more" ||
+        pagination.type === "auto_load_more"
+      ) {
+        resetGlobalPage()
+      }
+      recordScroll(pathname())
       handlePathChange(pathname(), retry_pass, force)
     },
     pageChange: pageChange,

--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -8,6 +8,8 @@ import {
   objStore,
   recordScroll,
   recoverScroll,
+  getScroll,
+  clearScroll,
   me,
 } from "~/store"
 import {
@@ -232,6 +234,9 @@ export const usePath = () => {
     },
     pageChange: pageChange,
     loadMore: () => {
+      if (getScroll(pathname()) < window.scrollY) {
+        clearScroll(pathname())
+      }
       pageChange(globalPage + 1, undefined, true)
     },
     allLoaded: () => globalPage >= Math.ceil(objStore.total / pagination.size),

--- a/src/pages/home/Obj.tsx
+++ b/src/pages/home/Obj.tsx
@@ -32,9 +32,9 @@ export const Obj = () => {
       useObjTitle()
       if (!first) {
         resetGlobalPage()
+        recordScroll(lastPathname)
       }
       first = false
-      recordScroll(lastPathname, window.scrollY)
       handlePathChange(pathname)
       lastPathname = pathname
     }),

--- a/src/store/scroll.ts
+++ b/src/store/scroll.ts
@@ -2,12 +2,13 @@ import { log } from "~/utils"
 
 export const ScrollMap = new Map<string, number>()
 
-export const recordScroll = (path: string, scroll: number) => {
+export const recordScroll = (path: string, scroll: number = window.scrollY) => {
   ScrollMap.set(path, scroll)
   log("recordScroll", path, scroll)
 }
 
 export const recoverScroll = (path: string) => {
+  if (!ScrollMap.has(path)) return
   window.scroll({
     top: ScrollMap.get(path) || 0,
     behavior: "smooth",

--- a/src/store/scroll.ts
+++ b/src/store/scroll.ts
@@ -15,3 +15,11 @@ export const recoverScroll = (path: string) => {
   })
   log("recoverScroll", path, ScrollMap.get(path))
 }
+
+export const getScroll = (path: string) => {
+  return ScrollMap.get(path) || 0
+}
+
+export const clearScroll = (path: string) => {
+  ScrollMap.delete(path)
+}


### PR DESCRIPTION
Fix: when the `Pagination type` is set to `Load more` or `Auto load more`:
修复：当『分页类型』为『加载更多』或『自动加载更多』时：

- After a refresh (e.g., rename, delete, etc.), only the current page is loaded, should load the current page and all preceding pages.
- 内容刷新后（如：重命名、删除等），只有当前分页内容会被加载，应当加载当前页及之前的所有页面。
- After navigating back or forward in the browser, only the first page is loaded, should load all the original pages.
- 浏览器后退、前进时，只有第一页内容会被加载，应当加载原来的所有分页。