### PR TITLE
fix(pagination): fix incorrect pagination after refreshing

### DIFF
--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -6,6 +6,7 @@ import {
   State,
   getPagination,
   objStore,
+  recordScroll,
   recoverScroll,
   me,
 } from "~/store"
@@ -131,9 +132,9 @@ export const usePath = () => {
     retry_pass = rp ?? false
     handleErr("")
     if (IsDirRecord[path]) {
-      handleFolder(path, globalPage, undefined, undefined, force)
+      return handleFolder(path, globalPage, undefined, undefined, force)
     } else {
-      handleObj(path)
+      return handleObj(path)
     }
   }
 
@@ -216,18 +217,34 @@ export const usePath = () => {
     }
   }
   const pageChange = (index?: number, size?: number, append = false) => {
-    handleFolder(pathname(), index, size, append)
+    return handleFolder(pathname(), index, size, append)
+  }
+  const loadMore = () => {
+    return pageChange(globalPage + 1, undefined, true)
   }
   return {
     handlePathChange: handlePathChange,
     setPathAs: setPathAs,
-    refresh: (retry_pass?: boolean, force?: boolean) => {
-      handlePathChange(pathname(), retry_pass, force)
+    refresh: async (retry_pass?: boolean, force?: boolean) => {
+      const path = pathname()
+      recordScroll(path)
+      if (
+        pagination.type === "load_more" ||
+        pagination.type === "auto_load_more"
+      ) {
+        const page = globalPage
+        resetGlobalPage()
+        await handlePathChange(path, retry_pass, force)
+        while (globalPage < page) {
+          await loadMore()
+        }
+      } else {
+        await handlePathChange(path, retry_pass, force)
+      }
+      recoverScroll(path)
     },
     pageChange: pageChange,
-    loadMore: () => {
-      pageChange(globalPage + 1, undefined, true)
-    },
+    loadMore: loadMore,
     allLoaded: () => globalPage >= Math.ceil(objStore.total / pagination.size),
   }
 }

--- a/src/store/scroll.ts
+++ b/src/store/scroll.ts
@@ -2,7 +2,7 @@ import { log } from "~/utils"
 
 export const ScrollMap = new Map<string, number>()
 
-export const recordScroll = (path: string, scroll: number) => {
+export const recordScroll = (path: string, scroll: number = window.scrollY) => {
   ScrollMap.set(path, scroll)
   log("recordScroll", path, scroll)
 }


### PR DESCRIPTION
Fix: when the `Pagination type` is set to `Load more` or `Auto load more`:
修复：当『分页类型』为『加载更多』或『自动加载更多』时：

- After a refresh (e.g., rename, delete, etc.), only the current page is loaded, should load the current page and all preceding pages.
- 内容刷新后（如：重命名、删除等），只有当前分页内容会被加载，应当加载当前页及之前的所有页面。