### PR TITLE
fix(request): abort obj request after going to new path

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -13,11 +13,18 @@ import { r } from "."
 export const fsGet = (
   path: string = "/",
   password = "",
+  cancelToken?: CancelToken,
 ): Promise<FsGetResp> => {
-  return r.post("/fs/get", {
-    path: path,
-    password: password,
-  })
+  return r.post(
+    "/fs/get",
+    {
+      path: path,
+      password: password,
+    },
+    {
+      cancelToken: cancelToken,
+    },
+  )
 }
 export const fsList = (
   path: string = "/",


### PR DESCRIPTION
Fix: going to a new page before the obj request is done, the obj may be shown in the new page.
修复：当前 obj 请求完成之前进入新的页面，可能导致新的页面显示的是原 obj。