### PR TITLE
fix(video): correct VTT subtitle styling in preview

### DIFF
--- a/src/pages/home/previews/video.tsx
+++ b/src/pages/home/previews/video.tsx
@@ -172,6 +172,7 @@ const Preview = () => {
       option.subtitle = {
         url: proxyLink(defaultSubtitle, true),
         type: ext(defaultSubtitle.name),
+        escape: false,
       }
     }
 


### PR DESCRIPTION
关闭了 html 标签的转义。这对于正确解析 VTT 字幕是必要的。例如，一个规范的 VTT 字幕经常带有说话人的信息，但在播放器解析时，会自动转义 html 标签，导致输出的字幕不正常。
以 [https://www.w3.org/TR/webvtt1/#introduction-caption](https://www.w3.org/TR/webvtt1/#introduction-caption) 中的字幕为例，对于
```
WEBVTT

00:11.000 --> 00:13.000
<v Roger Bingham>We are in New York City
```
现在会解析成`<v Roger Bingham>We are in New York City`，正确的解析应该是`We are in New York City`