### PR TITLE
feat(auth): use 'Token' as authentication header

### DIFF
--- a/src/lang/en/drivers.json
+++ b/src/lang/en/drivers.json
@@ -128,6 +128,7 @@
     "url": "Url"
   },
   "AList V3": {
+    "auth_header": "Authorization Header",
     "meta_password": "Meta password",
     "pass_ua_to_upsteam": "Pass ua to upsteam",
     "password": "Password",

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -52,11 +52,11 @@ instance.interceptors.response.use(
   },
 )
 
-instance.defaults.headers.common["Authorization"] =
+instance.defaults.headers.common["X-Token"] =
   localStorage.getItem("token") || ""
 
 export const changeToken = (token?: string) => {
-  instance.defaults.headers.common["Authorization"] = token ?? ""
+  instance.defaults.headers.common["X-Token"] = token ?? ""
   localStorage.setItem("token", token ?? "")
 }
 


### PR DESCRIPTION
fix https://github.com/AlistGo/alist/issues/3829
验证头部可以从‘Authorization’和‘Token’中二选一，避免与basic auth的冲突