### PR TITLE
fix(task): invalid path redirect

### DIFF
--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -11,6 +11,7 @@ import {
   recoverHistory,
   clearHistory,
   me,
+  recordHistory,
 } from "~/store"
 import {
   fsGet,
@@ -136,6 +137,7 @@ export const usePath = () => {
           ObjStore.setRelated(data.related ?? [])
           ObjStore.setRawUrl(data.raw_url)
           ObjStore.setState(State.File)
+          recordHistory(path, index)
         }
       },
       handleErr,
@@ -173,6 +175,7 @@ export const usePath = () => {
         ObjStore.setWrite(data.write)
         ObjStore.setProvider(data.provider)
         ObjStore.setState(State.Folder)
+        recordHistory(path, index ?? 1)
       },
       handleErr,
     )

--- a/src/lang/en/tasks.json
+++ b/src/lang/en/tasks.json
@@ -48,6 +48,7 @@
       "url": "URL",
       "path": "Destination Path",
       "transfer_src": "Source Path",
+      "transfer_src_local": "Source Path (Local)",
       "transfer_dst": "Destination Path"
     },
     "decompress": {

--- a/src/pages/home/Obj.tsx
+++ b/src/pages/home/Obj.tsx
@@ -10,12 +10,11 @@ import {
   Switch,
 } from "solid-js"
 import { Error, FullLoading, LinkWithBase } from "~/components"
-import { resetGlobalPage, useObjTitle, usePath, useRouter, useT } from "~/hooks"
+import { useObjTitle, usePath, useRouter, useT } from "~/hooks"
 import {
   getPagination,
   objStore,
   password,
-  recordHistory,
   setPassword,
   /*layout,*/ State,
 } from "~/store"
@@ -29,7 +28,6 @@ const Password = lazy(() => import("./Password"))
 const [objBoxRef, setObjBoxRef] = createSignal<HTMLDivElement>()
 export { objBoxRef }
 
-let first = true
 export const Obj = () => {
   const t = useT()
   const cardBg = useColorModeValue("white", "$neutral3")
@@ -41,19 +39,10 @@ export const Obj = () => {
       ? parseInt(searchParams["page"]) || 1
       : undefined
   })
-  let lastPathname = pathname()
-  let lastPage = page()
   createEffect(
     on([pathname, page], async ([pathname, page]) => {
       useObjTitle()
-      if (!first) {
-        recordHistory(lastPathname, lastPage)
-        resetGlobalPage()
-      }
-      first = false
       await handlePathChange(pathname, page)
-      lastPathname = pathname
-      lastPage = page
     }),
   )
   return (

--- a/src/pages/manage/tasks/Copy.tsx
+++ b/src/pages/manage/tasks/Copy.tsx
@@ -10,13 +10,16 @@ const Copy = () => {
       type="copy"
       canRetry
       nameAnalyzer={{
-        regex: /^copy \[(.+)]\((.*\/([^\/]+))\) to \[(.+)]\((.+)\)$/,
-        title: (matches) => matches[3],
+        regex: /^copy \[(.*\/([^\/]*))]\((.*\/([^\/]*))\) to \[(.+)]\((.+)\)$/,
+        title: (matches) => {
+          if (matches[4] !== "") return matches[4]
+          return matches[2] === "" ? "/" : matches[2]
+        },
         attrs: {
           [t(`tasks.attr.copy.src`)]: (matches) =>
-            getPath(matches[1], matches[2]),
+            getPath(matches[1], matches[3]),
           [t(`tasks.attr.copy.dst`)]: (matches) =>
-            getPath(matches[4], matches[5]),
+            getPath(matches[5], matches[6]),
         },
       }}
     />

--- a/src/pages/manage/tasks/Task.tsx
+++ b/src/pages/manage/tasks/Task.tsx
@@ -310,20 +310,21 @@ export const Task = (props: TaskAttribute & TasksProps & TaskLocalSetter) => {
             </Show>
             <Show when={matches !== null}>
               <For each={Object.entries(props.nameAnalyzer.attrs)}>
-                {(entry) => (
-                  <>
-                    <GridItem
-                      color="$neutral9"
-                      textAlign="right"
-                      css={{ whiteSpace: "nowrap" }}
-                    >
-                      {entry[0]}
-                    </GridItem>
-                    <GridItem color="$neutral9">
-                      {entry[1](matches as RegExpMatchArray)}
-                    </GridItem>
-                  </>
-                )}
+                {(entry) => {
+                  const value = entry[1](matches as RegExpMatchArray)
+                  return value === undefined ? null : (
+                    <Show when={entry[1] !== undefined}>
+                      <GridItem
+                        color="$neutral9"
+                        textAlign="right"
+                        css={{ whiteSpace: "nowrap" }}
+                      >
+                        {entry[0]}
+                      </GridItem>
+                      <GridItem color="$neutral9">{value}</GridItem>
+                    </Show>
+                  )
+                }}
               </For>
             </Show>
             <GridItem

--- a/src/pages/manage/tasks/helper.tsx
+++ b/src/pages/manage/tasks/helper.tsx
@@ -1,7 +1,8 @@
 import { createSignal, JSX } from "solid-js"
 import { me } from "~/store"
 import { TaskNameAnalyzer } from "./Tasks"
-import { useT } from "~/hooks"
+import { useRouter, useT } from "~/hooks"
+import { encodePath } from "~/utils"
 
 export const getPath = (
   device: string,
@@ -12,15 +13,18 @@ export const getPath = (
   const prefix = me().base_path === "/" ? "" : me().base_path
   const accessible = fullPath.startsWith(prefix)
   const [underline, setUnderline] = createSignal(false)
+  const { to } = useRouter()
   return accessible && asLink ? (
-    <a
+    <p
       style={underline() ? "text-decoration: underline" : ""}
       onMouseOver={() => setUnderline(true)}
       onMouseOut={() => setUnderline(false)}
-      href={fullPath.slice(prefix.length)}
+      on:click={(_: MouseEvent) => {
+        to(encodePath(fullPath.slice(prefix.length)))
+      }}
     >
       {fullPath}
-    </a>
+    </p>
   ) : (
     <p>{fullPath}</p>
   )
@@ -56,8 +60,12 @@ export const getOfflineDownloadTransferNameAnalyzer = (): TaskNameAnalyzer => {
     regex: /^transfer \[(.*)]\((.*\/([^\/]+))\) to \[(.+)]\((.+)\)$/,
     title: (matches) => matches[3],
     attrs: {
-      [t(`tasks.attr.offline_download.transfer_src`)]: (matches) =>
-        getPath(matches[1], matches[2], false),
+      [t(`tasks.attr.offline_download.transfer_src`)]: (matches) => {
+        return matches[1] === "" ? undefined : getPath(matches[1], matches[2])
+      },
+      [t(`tasks.attr.offline_download.transfer_src_local`)]: (matches) => {
+        return matches[1] === "" ? matches[2] : undefined
+      },
       [t(`tasks.attr.offline_download.transfer_dst`)]: (matches) =>
         getPath(matches[4], matches[5]),
     },

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -33,6 +33,7 @@ export const recordHistory = (path: string, page?: number) => {
     page: page ?? getGlobalPage(),
     scroll: window.scrollY,
   }
+  console.log(`record history: [${key}]`)
   HistoryMap.set(key, history)
 }
 


### PR DESCRIPTION
修复任务页面点击路径进行跳转时，文件夹内容会保持为上一次访问的文件夹的内容的问题。不知道是 #226 还是 #246 的问题，总之提前了记录历史的时机（从离开页面时到页面加载完毕时）从而修复了这个问题。
给驱动离线下载的源路径添加了跳转功能。