### PR TITLE
refactor(selection): refactor checkbox & drag selection

### DIFF
--- a/src/lang/en/home.json
+++ b/src/lang/en/home.json
@@ -143,14 +143,8 @@
     "open_item_on_checkbox": "Open item on Checkbox",
     "open_item_on_checkbox_options": {
       "direct": "Direct",
-      "disable_while_checked": "Disable while checked",
-      "with_ctrl": "With Ctrl/Command hold",
-      "with_alt": "With Alt/Option hold"
-    },
-    "select_with_mouse": "Select item with mouse while checkbox closed",
-    "select_with_mouse_options": {
-      "disabled": "Disabled",
-      "open_item_with_dblclick": "Open item with double click"
+      "dblclick": "Double click",
+      "disable_while_checked": "Disable while checked"
     }
   },
   "package_download": {

--- a/src/pages/home/folder/Grid.tsx
+++ b/src/pages/home/folder/Grid.tsx
@@ -12,7 +12,7 @@ const GridLayout = () => {
   return (
     <Grid
       oncapture:contextmenu={captureContentMenu}
-      classList={{ "viselect-container": isMouseSupported() }}
+      class="viselect-container"
       w="$full"
       gap="$1"
       templateColumns={`repeat(auto-fill, minmax(${

--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -1,24 +1,14 @@
 import { Center, VStack, Icon, Text } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
-import { batch, createMemo, createSignal, Show } from "solid-js"
+import { batch, Show } from "solid-js"
 import { CenterLoading, LinkWithPush, ImageWithError } from "~/components"
 import { usePath, useRouter, useUtil } from "~/hooks"
-import {
-  checkboxOpen,
-  getMainColor,
-  local,
-  selectAll,
-  selectIndex,
-} from "~/store"
+import { checkboxOpen, getMainColor, local, selectIndex } from "~/store"
 import { ObjType, StoreObj } from "~/types"
 import { bus, hoverColor } from "~/utils"
 import { getIconByObj } from "~/utils/icon"
-import {
-  ItemCheckbox,
-  useOpenItemWithCheckbox,
-  useSelectWithMouse,
-} from "./helper"
+import { ItemCheckbox, useSelectWithMouse } from "./helper"
 
 export const GridItem = (props: { obj: StoreObj; index: number }) => {
   const { isHide } = useUtil()
@@ -33,14 +23,10 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
       as={getIconByObj(props.obj)}
     />
   )
-  const [hover, setHover] = createSignal(false)
-  const showCheckbox = createMemo(
-    () => checkboxOpen() && (hover() || props.obj.selected),
-  )
   const { show } = useContextMenu({ id: 1 })
   const { pushHref, to } = useRouter()
-  const { isMouseSupported } = useSelectWithMouse()
-  const isShouldOpenItem = useOpenItemWithCheckbox()
+  const { openWithDoubleClick, toggleWithClick, restoreSelectionCache } =
+    useSelectWithMouse()
   return (
     <Motion.div
       initial={{ opacity: 0, scale: 0.9 }}
@@ -66,39 +52,31 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
         as={LinkWithPush}
         href={props.obj.name}
         cursor={
-          !isMouseSupported() && (!checkboxOpen() || isShouldOpenItem())
-            ? "pointer"
-            : "default"
+          openWithDoubleClick() || toggleWithClick() ? "default" : "pointer"
         }
         bgColor={props.obj.selected ? hoverColor() : undefined}
-        on:dblclick={(e: MouseEvent) => {
-          if (!isMouseSupported()) return
-          if (e.ctrlKey || e.metaKey || e.shiftKey) return
+        on:dblclick={() => {
+          if (!openWithDoubleClick()) return
+          selectIndex(props.index, true, true)
           to(pushHref(props.obj.name))
         }}
         on:click={(e: MouseEvent) => {
-          if (isMouseSupported()) return e.preventDefault()
-          if (!checkboxOpen()) return
           e.preventDefault()
-          if (isShouldOpenItem()) {
-            to(pushHref(props.obj.name))
-            return
-          }
-          selectIndex(props.index, !props.obj.selected)
+          if (openWithDoubleClick()) return
+          if (e.ctrlKey || e.metaKey || e.shiftKey) return
+          if (!restoreSelectionCache()) return
+          if (toggleWithClick())
+            return selectIndex(props.index, !props.obj.selected)
+          to(pushHref(props.obj.name))
         }}
         onMouseEnter={() => {
-          setHover(true)
           setPathAs(props.obj.name, props.obj.is_dir, true)
-        }}
-        onMouseLeave={() => {
-          setHover(false)
         }}
         onContextMenu={(e: MouseEvent) => {
           batch(() => {
             // if (!checkboxOpen()) {
             //   toggleCheckbox();
             // }
-            selectAll(false)
             selectIndex(props.index, true, true)
           })
           show(e, { props: props.obj })
@@ -108,26 +86,18 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
           class="item-thumbnail"
           h={`${parseInt(local["grid_item_size"])}px`}
           w="$full"
-          on:dblclick={(e: MouseEvent) => {
-            if (!isMouseSupported()) return
-            if (props.obj.type === ObjType.IMAGE) {
-              e.stopPropagation()
-              e.preventDefault()
-              bus.emit("gallery", props.obj.name)
-            }
-          }}
+          cursor={props.obj.type !== ObjType.IMAGE ? "inherit" : "pointer"}
           on:click={(e: MouseEvent) => {
-            if (isMouseSupported()) return
-            if (checkboxOpen() && !isShouldOpenItem()) return
-            if (props.obj.type === ObjType.IMAGE) {
-              e.stopPropagation()
-              e.preventDefault()
-              bus.emit("gallery", props.obj.name)
-            }
+            if (props.obj.type !== ObjType.IMAGE) return
+            if (e.ctrlKey || e.metaKey || e.shiftKey) return
+            if (!restoreSelectionCache()) return
+            bus.emit("gallery", props.obj.name)
+            e.preventDefault()
+            e.stopPropagation()
           }}
           pos="relative"
         >
-          <Show when={showCheckbox()}>
+          <Show when={checkboxOpen()}>
             <ItemCheckbox
               pos="absolute"
               left="$1"

--- a/src/pages/home/folder/GridItem.tsx
+++ b/src/pages/home/folder/GridItem.tsx
@@ -133,6 +133,9 @@ export const GridItem = (props: { obj: StoreObj; index: number }) => {
               left="$1"
               top="$1"
               // colorScheme="neutral"
+              on:mousedown={(e: MouseEvent) => {
+                e.stopPropagation()
+              }}
               on:click={(e: MouseEvent) => {
                 e.stopPropagation()
               }}

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -76,6 +76,12 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
               pos="absolute"
               left="$1"
               top="$1"
+              on:mousedown={(e: MouseEvent) => {
+                e.stopPropagation()
+              }}
+              on:click={(e: MouseEvent) => {
+                e.stopPropagation()
+              }}
               checked={props.obj.selected}
               onChange={(e: any) => {
                 selectIndex(props.index, e.target.checked)

--- a/src/pages/home/folder/ImageItem.tsx
+++ b/src/pages/home/folder/ImageItem.tsx
@@ -1,18 +1,14 @@
 import { Center, VStack, Icon } from "@hope-ui/solid"
 import { Motion } from "@motionone/solid"
 import { useContextMenu } from "solid-contextmenu"
-import { batch, createMemo, createSignal, Show } from "solid-js"
+import { batch, Show } from "solid-js"
 import { CenterLoading, ImageWithError } from "~/components"
 import { useLink, usePath, useUtil } from "~/hooks"
 import { checkboxOpen, getMainColor, selectAll, selectIndex } from "~/store"
 import { ObjType, StoreObj } from "~/types"
 import { bus } from "~/utils"
 import { getIconByObj } from "~/utils/icon"
-import {
-  ItemCheckbox,
-  useOpenItemWithCheckbox,
-  useSelectWithMouse,
-} from "./helper"
+import { ItemCheckbox, useSelectWithMouse } from "./helper"
 
 export const ImageItem = (props: { obj: StoreObj; index: number }) => {
   const { isHide } = useUtil()
@@ -23,14 +19,10 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
   const objIcon = (
     <Icon color={getMainColor()} boxSize="$12" as={getIconByObj(props.obj)} />
   )
-  const [hover, setHover] = createSignal(false)
-  const showCheckbox = createMemo(
-    () => checkboxOpen() && (hover() || props.obj.selected),
-  )
   const { show } = useContextMenu({ id: 1 })
   const { rawLink } = useLink()
-  const { isMouseSupported } = useSelectWithMouse()
-  const isShouldOpenItem = useOpenItemWithCheckbox()
+  const { openWithDoubleClick, toggleWithClick, restoreSelectionCache } =
+    useSelectWithMouse()
   return (
     <Motion.div
       initial={{ opacity: 0, scale: 0.9 }}
@@ -53,25 +45,21 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
         _hover={{
           border: `2px solid ${getMainColor()}`,
         }}
+        cursor={
+          openWithDoubleClick() || toggleWithClick() ? "default" : "pointer"
+        }
         onMouseEnter={() => {
-          setHover(true)
           setPathAs(props.obj.name, props.obj.is_dir, true)
-        }}
-        onMouseLeave={() => {
-          setHover(false)
         }}
         onContextMenu={(e: MouseEvent) => {
           batch(() => {
-            selectAll(false)
             selectIndex(props.index, true, true)
           })
           show(e, { props: props.obj })
         }}
       >
         <Center w="$full" pos="relative">
-          <Show
-            when={showCheckbox() || (isMouseSupported() && props.obj.selected)}
-          >
+          <Show when={checkboxOpen()}>
             <ItemCheckbox
               pos="absolute"
               left="$1"
@@ -98,23 +86,18 @@ export const ImageItem = (props: { obj: StoreObj; index: number }) => {
             fallbackErr={objIcon}
             src={rawLink(props.obj)}
             loading="lazy"
-            cursor={
-              !isMouseSupported() && (!checkboxOpen() || isShouldOpenItem())
-                ? "pointer"
-                : "default"
-            }
-            on:dblclick={(e: MouseEvent) => {
-              if (!isMouseSupported()) return
-              if (e.ctrlKey || e.metaKey || e.shiftKey) return
+            on:dblclick={() => {
+              if (!openWithDoubleClick()) return
               bus.emit("gallery", props.obj.name)
+              selectIndex(props.index, true, true)
             }}
-            on:click={() => {
-              if (isMouseSupported()) return
-              if (!checkboxOpen() || isShouldOpenItem()) {
-                bus.emit("gallery", props.obj.name)
-                return
-              }
-              selectIndex(props.index, !props.obj.selected)
+            on:click={(e: MouseEvent) => {
+              if (openWithDoubleClick()) return
+              if (e.ctrlKey || e.metaKey || e.shiftKey) return
+              if (!restoreSelectionCache()) return
+              if (toggleWithClick())
+                return selectIndex(props.index, !props.obj.selected)
+              bus.emit("gallery", props.obj.name)
             }}
           />
         </Center>

--- a/src/pages/home/folder/Images.tsx
+++ b/src/pages/home/folder/Images.tsx
@@ -29,7 +29,7 @@ const ImageLayout = (props: { images: StoreObj[] }) => {
   return (
     <VStack
       oncapture:contextmenu={captureContentMenu}
-      classList={{ "viselect-container": isMouseSupported() }}
+      class="viselect-container"
       spacing="$2"
       w="$full"
     >

--- a/src/pages/home/folder/List.tsx
+++ b/src/pages/home/folder/List.tsx
@@ -92,8 +92,7 @@ const ListLayout = () => {
     <VStack
       onDragOver={onDragOver}
       oncapture:contextmenu={captureContentMenu}
-      classList={{ "viselect-container": isMouseSupported() }}
-      class="list"
+      class="list viselect-container"
       w="$full"
       spacing="$1"
     >

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -9,17 +9,12 @@ import {
   getMainColor,
   local,
   OrderBy,
-  selectAll,
   selectIndex,
 } from "~/store"
 import { ObjType, StoreObj } from "~/types"
 import { bus, formatDate, getFileSize, hoverColor } from "~/utils"
 import { getIconByObj } from "~/utils/icon"
-import {
-  ItemCheckbox,
-  useOpenItemWithCheckbox,
-  useSelectWithMouse,
-} from "./helper"
+import { ItemCheckbox, useSelectWithMouse } from "./helper"
 
 export interface Col {
   name: OrderBy
@@ -41,8 +36,8 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
   const { setPathAs } = usePath()
   const { show } = useContextMenu({ id: 1 })
   const { pushHref, to } = useRouter()
-  const { isMouseSupported } = useSelectWithMouse()
-  const isShouldOpenItem = useOpenItemWithCheckbox()
+  const { openWithDoubleClick, toggleWithClick, restoreSelectionCache } =
+    useSelectWithMouse()
   const filenameStyle = () => local["list_item_filename_overflow"]
   return (
     <Motion.div
@@ -68,25 +63,22 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
         as={LinkWithPush}
         href={props.obj.name}
         cursor={
-          !isMouseSupported() && (!checkboxOpen() || isShouldOpenItem())
-            ? "pointer"
-            : "default"
+          openWithDoubleClick() || toggleWithClick() ? "default" : "pointer"
         }
         bgColor={props.obj.selected ? hoverColor() : undefined}
-        on:dblclick={(e: MouseEvent) => {
-          if (!isMouseSupported()) return
-          if (e.ctrlKey || e.metaKey || e.shiftKey) return
+        on:dblclick={() => {
+          if (!openWithDoubleClick()) return
+          selectIndex(props.index, true, true)
           to(pushHref(props.obj.name))
         }}
         on:click={(e: MouseEvent) => {
-          if (isMouseSupported()) return e.preventDefault()
-          if (!checkboxOpen()) return
           e.preventDefault()
-          if (isShouldOpenItem()) {
-            to(pushHref(props.obj.name))
-            return
-          }
-          selectIndex(props.index, !props.obj.selected)
+          if (openWithDoubleClick()) return
+          if (e.ctrlKey || e.metaKey || e.shiftKey) return
+          if (!restoreSelectionCache()) return
+          if (toggleWithClick())
+            return selectIndex(props.index, !props.obj.selected)
+          to(pushHref(props.obj.name))
         }}
         onMouseEnter={() => {
           setPathAs(props.obj.name, props.obj.is_dir, true)
@@ -96,7 +88,6 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
             // if (!checkboxOpen()) {
             //   toggleCheckbox();
             // }
-            selectAll(false)
             selectIndex(props.index, true, true)
           })
           show(e, { props: props.obj })
@@ -124,12 +115,14 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
             color={getMainColor()}
             as={getIconByObj(props.obj)}
             mr="$1"
+            cursor={props.obj.type !== ObjType.IMAGE ? "inherit" : "pointer"}
             on:click={(e: MouseEvent) => {
-              if (props.obj.type === ObjType.IMAGE) {
-                e.stopPropagation()
-                e.preventDefault()
-                bus.emit("gallery", props.obj.name)
-              }
+              if (props.obj.type !== ObjType.IMAGE) return
+              if (e.ctrlKey || e.metaKey || e.shiftKey) return
+              if (!restoreSelectionCache()) return
+              bus.emit("gallery", props.obj.name)
+              e.preventDefault()
+              e.stopPropagation()
             }}
           />
           <Text

--- a/src/pages/home/folder/ListItem.tsx
+++ b/src/pages/home/folder/ListItem.tsx
@@ -106,6 +106,9 @@ export const ListItem = (props: { obj: StoreObj; index: number }) => {
           <Show when={checkboxOpen()}>
             <ItemCheckbox
               // colorScheme="neutral"
+              on:mousedown={(e: MouseEvent) => {
+                e.stopPropagation()
+              }}
               on:click={(e: MouseEvent) => {
                 e.stopPropagation()
               }}

--- a/src/pages/home/folder/helper.ts
+++ b/src/pages/home/folder/helper.ts
@@ -70,7 +70,7 @@ export function useSelectWithMouse() {
         }
         if (!ev.shiftKey && !ev.ctrlKey && !ev.metaKey) {
           selectAll(false)
-          selection.clearSelection(true, true)
+          selection.clearSelection(true)
         }
       })
       selection.on(

--- a/src/pages/home/folder/helper.ts
+++ b/src/pages/home/folder/helper.ts
@@ -51,7 +51,7 @@ export function useOpenItemWithCheckbox() {
 export function useSelectWithMouse() {
   const disabled = () => local["select_with_mouse"] === "disabled"
 
-  const isMouseSupported = () => !isMobile && !disabled() && !checkboxOpen()
+  const isMouseSupported = () => !isMobile && !disabled()
 
   const registerSelectContainer = () => {
     createEffect(() => {
@@ -62,13 +62,15 @@ export function useSelectWithMouse() {
         boundaries: [".viselect-container"],
         selectables: [".viselect-item"],
       })
-      selection.on("start", ({ event }) => {
-        const ev = event as MouseEvent
+      selection.on("beforestart", () => {
         selection.clearSelection(true, true)
         selection.select(".viselect-item.selected", true)
+      })
+      selection.on("start", ({ event }) => {
+        const ev = event as MouseEvent
         if (!ev.ctrlKey && !ev.metaKey) {
           selectAll(false)
-          selection.clearSelection()
+          selection.clearSelection(true, true)
         }
       })
       selection.on(

--- a/src/store/local_settings.ts
+++ b/src/store/local_settings.ts
@@ -57,17 +57,7 @@ export const initialLocalSettings = [
     key: "open_item_on_checkbox",
     default: "direct",
     type: "select",
-    options: () =>
-      isMobile
-        ? ["direct", "disable_while_checked"]
-        : ["direct", "disable_while_checked", "with_alt", "with_ctrl"],
-  },
-  {
-    key: "select_with_mouse",
-    default: "disabled",
-    type: "select",
-    options: ["disabled", "open_item_with_dblclick"],
-    hidden: isMobile,
+    options: ["direct", "dblclick", "disable_while_checked"],
   },
 ]
 export type LocalSetting = (typeof initialLocalSettings)[number]


### PR DESCRIPTION
Checkboxes and drag selection are both used for multiple selection, while both of them are very useful, they are incompatible with each other, making the options and states complex.
复选框和拖拽选择的目的都是为了多选，这两者都很有用，但它们互相之间不兼容，导致相关选项和状态复杂。

- Compatible with checkbox and drag selection
- 兼容复选框及拖拽选择
- Preserve selection state when navigating between pages
- 页面切换时保持选中状态
- Fix issues with drag selection state
- 修复拖拽选择状态问题
- Fix selection behaviour with `Shift` key
- 修复按下 `Shift` 键时的选择表现
- Simplify checkbox & drag selection options
- 简化复选框、拖拽选择选项
