### PR TITLE
fix(history): rebuild the recovering history obj to prevent reference issues

### DIFF
--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -44,7 +44,7 @@ export const recoverHistory = async (path: string, page?: number) => {
   setGlobalPage(history.page)
   ObjStore.setState(State.Initial)
   await waitForNextFrame()
-  ObjStore.set(history.obj)
+  ObjStore.set(JSON.parse(JSON.stringify(history.obj)))
   await waitForNextFrame()
   window.scroll({ top: history.scroll, behavior: "smooth" })
 }


### PR DESCRIPTION
Rebuild the recovering history obj to prevent reference issues.
恢复历史数据时构造新的对象，以避免引用导致的混乱问题。