### PR TITLE
fix(authn): cancel webauthn login on clean up

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -12,7 +12,7 @@ import {
   Checkbox,
   Icon,
 } from "@hope-ui/solid"
-import { createMemo, createSignal, Show, onMount } from "solid-js"
+import { createMemo, createSignal, Show, onMount, onCleanup } from "solid-js"
 import { SwitchColorMode, SwitchLanguageWhite } from "~/components"
 import { useFetch, useT, useTitle, useRouter } from "~/hooks"
 import {
@@ -169,6 +169,18 @@ const Login = () => {
       }
     })
   }
+  const AuthnCleanUpHandler = () => AuthnSignal?.abort()
+  onMount(() => {
+    if (AuthnSignEnabled) {
+      window.addEventListener("beforeunload", AuthnCleanUpHandler)
+      AuthnLogin(true)
+    }
+  })
+  onCleanup(() => {
+    AuthnSignal?.abort()
+    window.removeEventListener("beforeunload", AuthnCleanUpHandler)
+  })
+
   const Login = async () => {
     if (!useauthn()) {
       if (remember() === "true") {
@@ -207,10 +219,6 @@ const Login = () => {
   if (ldapLoginEnabled) {
     setUseLdap(true)
   }
-
-  onMount(() => {
-    AuthnLogin(true)
-  })
 
   return (
     <Center zIndex="1" w="$full" h="100vh">


### PR DESCRIPTION
Fixed for following senarios:

- Webauthn login is not canceled after page exit.
- Conditional webauthn login is running even webauthn is not enabled.

Image for test: `mmx233/alist:frontend-20250416`

May fix:

- https://github.com/AlistGo/alist/issues/8339