### PR TITLE
fix(sso): webauthn conditional login is not compatible with sso

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -132,7 +132,6 @@ const Login = () => {
     AuthnSignal?.abort()
     const controller = new AbortController()
     AuthnSignal = controller
-    changeToken()
     const username_login: string = conditional ? "" : username()
     if (!conditional && remember() === "true") {
       localStorage.setItem("username", username())


### PR DESCRIPTION
Change token to `undefined` will cause sso not able to set valid tokens. But in another hand if we have a invalid token, we will also get errors in conditional webauthn login flow, so we need to modify webauthn api for this.

fixes:

- https://github.com/AlistGo/alist/issues/8283
- https://github.com/AlistGo/alist/issues/8165