### PR TITLE
feat(video): handle player error by removing Cross-Origin attribute

### DIFF
--- a/src/pages/home/previews/aliyun_video.tsx
+++ b/src/pages/home/previews/aliyun_video.tsx
@@ -348,6 +348,14 @@ const Preview = () => {
       })
       interval = window.setInterval(resetPlayUrl, 1000 * 60 * 14)
     })
+    player.on("error", () => {
+      if (player.video.crossOrigin) {
+        console.log(
+          "Error detected. Trying to remove Cross-Origin attribute. Screenshot may not be available.",
+        )
+        player.video.crossOrigin = null
+      }
+    })
   })
   let interval: number
   let curSeek: number

--- a/src/pages/home/previews/video.tsx
+++ b/src/pages/home/previews/video.tsx
@@ -311,6 +311,14 @@ const Preview = () => {
       if (!autoNext()) return
       next_video()
     })
+    player.on("error", () => {
+      if (player.video.crossOrigin) {
+        console.log(
+          "Error detected. Trying to remove Cross-Origin attribute. Screenshot may not be available.",
+        )
+        player.video.crossOrigin = null
+      }
+    })
   })
   onCleanup(() => {
     if (player && player.video) player.video.src = ""


### PR DESCRIPTION
修复 https://github.com/AlistGo/alist-web/pull/269 引入的 BUG。截图和跨域只能二选一，加入错误事件处理，尝试在错误时取消 `crossOrigin` 参数。

Close: https://github.com/AlistGo/alist/issues/8414