### PR TITLE
fix(audio): ensure cover image falls back to thumbnail if available

### DIFF
--- a/src/pages/home/previews/audio.tsx
+++ b/src/pages/home/previews/audio.tsx
@@ -38,6 +38,7 @@ const Preview = () => {
       cover = rawLink(coverObj, true)
     } else {
       cover =
+        obj.thumb ||
         getSetting("audio_cover") ||
         "https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg"
     }


### PR DESCRIPTION
补充：https://github.com/AlistGo/alist-web/pull/271