### PR TITLE
perf: lazy load for math rendering

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -214,8 +214,12 @@ export function Markdown(props: {
     })
     return content
   })
-  const [remarkPlugins, setRemarkPlugins] = createSignal<any[]>([remarkGfm])
-  const [rehypePlugins, setRehypePlugins] = createSignal<any[]>([rehypeRaw])
+  const [remarkPlugins, setRemarkPlugins] = createSignal<Function[]>([
+    remarkGfm,
+  ])
+  const [rehypePlugins, setRehypePlugins] = createSignal<Function[]>([
+    rehypeRaw,
+  ])
   createEffect(
     on(md, async () => {
       setShow(false)


### PR DESCRIPTION
检测 Markdown 内容是否包含公式，动态导入 `remark-math` 和 `rehype-katex`，以便减小首页 js 的体积。

### 背景

由于浏览数学公式并非常见需求，且 https://github.com/AlistGo/alist/pull/7923 引入的默认启用的服务端渲染 Markdown 会使数学公式无法渲染，修改为动态导入能够最多节约服务器 20% 的流量。

### 效果

下面是在 main 分支和本 pr 分支两次打包的对比

#### 使用 `rollup-plugin-visualizer` 检测

Before:

![](https://github.com/user-attachments/assets/367ea808-93b7-4cb1-9ad9-0c2ca54a85a4)

After:

![](https://github.com/user-attachments/assets/6f1c261a-c725-49a0-8541-d9ae72265624)

#### `vite` log

Before:

```powershell
D:\temp\alist-web [md +1 ~4 -0 !]> pnpm build        

> alist-web@0.0.0 build D:\temp\alist-web
> vite build

vite v4.5.13 building for production...
✓ 884 modules transformed.
[plugin:vite:reporter]
(!) D:/temp/alist-web/src/pages/home/previews/download.tsx is dynamically imported by D:/temp/alist-web/src/pages/home/previews/index.ts but also statically imported by D:/temp/alist-web/src/pages/home/file/File.tsx, dynamic import will not move module into another chunk.

dist/assets/item_type-legacy.1b6076a1.js                           0.22 kB │ gzip:   0.17 kB
dist/assets/Wether-legacy.40f8218c.js                              0.32 kB │ gzip:   0.23 kB
dist/assets/ResponsiveGrid-legacy.d4e416ec.js                      0.38 kB │ gzip:   0.29 kB
dist/assets/index-legacy.e5882590.js                               0.40 kB │ gzip:   0.26 kB
dist/assets/Decompress-legacy.3711957f.js                          0.63 kB │ gzip:   0.37 kB
dist/assets/offline_download-legacy.fd7a9271.js                    0.65 kB │ gzip:   0.38 kB
dist/assets/useTitle-legacy.fd5f9e9a.js                            0.69 kB │ gzip:   0.40 kB
dist/assets/Upload-legacy.285e595f.js                              0.71 kB │ gzip:   0.44 kB
dist/assets/DeletePopover-legacy.3daebfef.js                       0.79 kB │ gzip:   0.39 kB
dist/assets/Copy-legacy.06350db6.js                                0.88 kB │ gzip:   0.50 kB
dist/assets/index-legacy.bf9e8847.js                               0.95 kB │ gzip:   0.48 kB
dist/assets/Password-legacy.70e98ae5.js                            1.07 kB │ gzip:   0.56 kB
dist/assets/image-legacy.2f8f3b46.js                               1.16 kB │ gzip:   0.61 kB
dist/assets/Grid-legacy.ff8f29b3.js                                1.18 kB │ gzip:   0.62 kB
dist/assets/ImageWithError-legacy.8cdcf4af.js                      1.35 kB │ gzip:   0.77 kB
dist/assets/markdown_with_word_wrap-legacy.a87a936f.js             1.38 kB │ gzip:   0.78 kB
dist/assets/markdown-legacy.83114ae1.js                            1.41 kB │ gzip:   0.80 kB
dist/assets/html-legacy.a012ebc0.js                                1.77 kB │ gzip:   0.96 kB
dist/assets/plist-legacy.0debe174.js                               1.79 kB │ gzip:   0.96 kB
dist/assets/url-legacy.47aa004e.js                                 1.87 kB │ gzip:   0.99 kB
dist/assets/ipa-legacy.7fbfe953.js                                 2.25 kB │ gzip:   1.15 kB
dist/assets/SettingItem-legacy.46ee3868.js                         3.52 kB │ gzip:   1.27 kB
dist/assets/GridItem-legacy.948957f8.js                            3.68 kB │ gzip:   1.65 kB
dist/assets/Paginator-legacy.91400ec1.js                           3.83 kB │ gzip:   1.51 kB
dist/assets/index-legacy.99b77b08.js                               3.98 kB │ gzip:   0.67 kB
dist/assets/Images-legacy.b4ad658b.js                              4.23 kB │ gzip:   1.84 kB
dist/assets/icon-legacy.6afcd078.js                                6.24 kB │ gzip:   3.09 kB
dist/assets/List-legacy.e7f4a0a7.js                                6.75 kB │ gzip:   2.87 kB
dist/assets/About-legacy.37cd8f90.js                               8.89 kB │ gzip:   3.39 kB
dist/assets/aliyun_office-legacy.f31d0ffe.js                       8.97 kB │ gzip:   3.48 kB
dist/assets/Messenger-legacy.8fe3eff5.js                          10.22 kB │ gzip:   3.85 kB
dist/assets/Common-legacy.fef0e4c9.js                             10.43 kB │ gzip:   3.96 kB
dist/assets/Metas-legacy.4885f520.js                              10.64 kB │ gzip:   3.99 kB
dist/assets/2fa-legacy.fc061a98.js                                10.91 kB │ gzip:   4.06 kB
dist/assets/index-legacy.bed1804a.js                              11.16 kB │ gzip:   3.49 kB
dist/assets/webauthn-json.browser-ponyfill-legacy.1eb8248a.js     11.84 kB │ gzip:   4.21 kB
dist/assets/Users-legacy.10fd231b.js                              11.86 kB │ gzip:   4.29 kB
dist/assets/AddOrEdit-legacy.0c5c3aa2.js                          12.23 kB │ gzip:   4.45 kB
dist/assets/AddOrEdit-legacy.50800d74.js                          12.41 kB │ gzip:   4.51 kB
dist/assets/FolderTree-legacy.5fd89d05.js                         13.22 kB │ gzip:   4.91 kB
dist/assets/PublicKeys-legacy.9febb8b0.js                         13.23 kB │ gzip:   4.62 kB
dist/assets/Storages-legacy.97366490.js                           14.57 kB │ gzip:   4.95 kB
dist/assets/indexes-legacy.8fff6a26.js                            14.85 kB │ gzip:   5.08 kB
dist/assets/style-legacy.772f295b.js                              14.92 kB │ gzip:   4.76 kB
dist/assets/S3-legacy.bf6309f3.js                                 15.44 kB │ gzip:   5.27 kB
dist/assets/aliyun_video-legacy.18374f09.js                       16.15 kB │ gzip:   6.09 kB
dist/assets/Other-legacy.638001d5.js                              16.58 kB │ gzip:   4.84 kB
dist/assets/AddOrEdit-legacy.e1dfd3a5.js                          16.64 kB │ gzip:   5.46 kB
dist/assets/Profile-legacy.6985e8d0.js                            16.72 kB │ gzip:   5.75 kB
dist/assets/archive-legacy.c9a568c1.js                            17.54 kB │ gzip:   6.51 kB
dist/assets/backup-restore-legacy.8f849bc6.js                     18.02 kB │ gzip:   6.11 kB
dist/assets/index-legacy.e2146e72.js                              18.51 kB │ gzip:   6.74 kB
dist/assets/index-legacy.9dfaf2bb.js                              19.90 kB │ gzip:   6.60 kB
dist/assets/PackageDownload-legacy.0efdd3c8.js                    20.59 kB │ gzip:   7.54 kB
dist/assets/text-editor-legacy.331edab5.js                        21.11 kB │ gzip:   7.10 kB
dist/assets/helper-legacy.bc29499a.js                             22.53 kB │ gzip:   7.29 kB
dist/assets/helper-legacy.6ea39f73.js                             26.40 kB │ gzip:   8.03 kB
dist/assets/File-legacy.4dfce507.js                               32.62 kB │ gzip:  12.26 kB
dist/assets/entry-legacy.f39e5e6a.js                              34.67 kB │ gzip:  15.00 kB
dist/assets/entry-legacy.560286ea.js                              46.74 kB │ gzip:  12.92 kB
dist/assets/Upload-legacy.0fc5191a.js                             57.21 kB │ gzip:  20.44 kB
dist/assets/Layout-legacy.91a45436.js                             65.52 kB │ gzip:  19.41 kB
dist/assets/index-legacy.f02f0b7f.js                              67.25 kB │ gzip:  25.84 kB
dist/assets/audio-legacy.67d62430.js                              75.38 kB │ gzip:  17.46 kB
dist/assets/polyfills-legacy.f1451f88.js                         125.76 kB │ gzip:  50.44 kB
dist/assets/video360-legacy.247fc480.js                          144.40 kB │ gzip:  38.23 kB
dist/assets/Folder-legacy.a276424e.js                            151.49 kB │ gzip:  41.71 kB
dist/assets/video_box-legacy.d988ec94.js                         188.34 kB │ gzip:  46.37 kB
dist/assets/asciinema-legacy.a054d309.js                         229.66 kB │ gzip:  77.24 kB
dist/assets/video-legacy.c07f43e4.js                             279.75 kB │ gzip:  65.06 kB
dist/assets/hls-legacy.9c330849.js                               628.56 kB │ gzip: 182.81 kB
dist/assets/index-legacy.365e8be1.js                           1,332.83 kB │ gzip: 385.78 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
[plugin:vite:reporter]
(!) D:/temp/alist-web/src/pages/home/previews/download.tsx is dynamically imported by D:/temp/alist-web/src/pages/home/previews/index.ts but also statically imported by D:/temp/alist-web/src/pages/home/file/File.tsx, dynamic import will not move module into another chunk.

dist/index.html                                             4.01 kB │ gzip:   1.52 kB
dist/assets/loading-298ad3ff.gif                            4.18 kB
dist/assets/lg-22b72ba5.ttf                                 4.76 kB
dist/assets/lg-fefc5c0d.woff                                4.83 kB
dist/assets/lg-f2fe1c00.svg                                12.83 kB │ gzip:   4.60 kB
dist/assets/subtitles-octopus-worker-f95f2186.js          399.69 kB
dist/assets/TimesNewRoman-d9fb32eb.ttf                    834.24 kB
dist/assets/subtitles-octopus-worker-62892886.wasm      2,305.84 kB
dist/assets/SourceHanSansCN-Bold-b5627435.woff2         5,002.93 kB
dist/assets/style-a6d16836.css                              4.31 kB │ gzip:   0.94 kB
dist/assets/video360-f0192288.css                          12.18 kB │ gzip:   3.02 kB
dist/assets/audio-43f4c02b.css                             13.47 kB │ gzip:   2.63 kB
dist/assets/index-c0564af7.css                             19.20 kB │ gzip:   4.25 kB
dist/assets/Folder-6ee8584f.css                            32.29 kB │ gzip:   8.06 kB
dist/assets/asciinema-53412307.css                         44.98 kB │ gzip:   6.60 kB
dist/assets/item_type-32dc6fdf.js                           0.14 kB │ gzip:   0.13 kB
dist/assets/Wether-c356b4be.js                              0.22 kB │ gzip:   0.18 kB
dist/assets/ImageWithError-dfe1f64b.js                      0.24 kB │ gzip:   0.20 kB
dist/assets/index-8e63f2d3.js                               0.26 kB │ gzip:   0.20 kB
dist/assets/markdown_with_word_wrap-79dd7f0f.js             0.27 kB │ gzip:   0.21 kB
dist/assets/ResponsiveGrid-40a06c7b.js                      0.29 kB │ gzip:   0.24 kB
dist/assets/markdown-192de7fe.js                            0.30 kB │ gzip:   0.22 kB
dist/assets/About-ea87a236.js                               0.39 kB │ gzip:   0.28 kB
dist/assets/Upload-0b40ce52.js                              0.44 kB │ gzip:   0.31 kB
dist/assets/Decompress-5a46ab39.js                          0.49 kB │ gzip:   0.31 kB
dist/assets/aliyun_office-9bdcbdee.js                       0.50 kB │ gzip:   0.35 kB
dist/assets/useTitle-a2f3842b.js                            0.50 kB │ gzip:   0.33 kB
dist/assets/offline_download-1c856d56.js                    0.51 kB │ gzip:   0.32 kB
dist/assets/Copy-6ee1abf1.js                                0.55 kB │ gzip:   0.36 kB
dist/assets/plist-b192d8a5.js                               0.62 kB │ gzip:   0.38 kB
dist/assets/html-87a9b89e.js                                0.64 kB │ gzip:   0.38 kB
dist/assets/DeletePopover-62fc431d.js                       0.67 kB │ gzip:   0.33 kB
dist/assets/url-c2634a39.js                                 0.71 kB │ gzip:   0.41 kB
dist/assets/index-adfa0b32.js                               0.87 kB │ gzip:   0.43 kB
dist/assets/Password-d71ac840.js                            0.93 kB │ gzip:   0.50 kB
dist/assets/image-e35346d6.js                               0.94 kB │ gzip:   0.54 kB
dist/assets/Grid-343c5e47.js                                0.95 kB │ gzip:   0.55 kB
dist/assets/ipa-3dd50148.js                                 1.02 kB │ gzip:   0.55 kB
dist/assets/2fa-38b2cc52.js                                 1.31 kB │ gzip:   0.68 kB
dist/assets/Messenger-d9860176.js                           1.34 kB │ gzip:   0.68 kB
dist/assets/Common-c769160d.js                              1.35 kB │ gzip:   0.71 kB
dist/assets/Metas-ac5c539c.js                               1.79 kB │ gzip:   0.77 kB
dist/assets/webauthn-json.browser-ponyfill-f2f06d6e.js      2.37 kB │ gzip:   0.99 kB
dist/assets/Paginator-6f02ef71.js                           2.48 kB │ gzip:   0.90 kB
dist/assets/SettingItem-56d54c91.js                         2.56 kB │ gzip:   0.91 kB
dist/assets/GridItem-1f528cb5.js                            2.61 kB │ gzip:   1.25 kB
dist/assets/Users-ceeae65c.js                               2.71 kB │ gzip:   1.06 kB
dist/assets/AddOrEdit-6720f2df.js                           2.82 kB │ gzip:   1.12 kB
dist/assets/AddOrEdit-fc43e2ee.js                           3.12 kB │ gzip:   1.17 kB
dist/assets/Images-e802dda8.js                              3.18 kB │ gzip:   1.45 kB
dist/assets/S3-49729379.js                                  3.89 kB │ gzip:   1.51 kB
dist/assets/index-2ef814d2.js                               3.89 kB │ gzip:   0.61 kB
dist/assets/PublicKeys-730c0d2d.js                          3.90 kB │ gzip:   1.36 kB
dist/assets/FolderTree-2398852b.js                          4.01 kB │ gzip:   1.64 kB
dist/assets/List-099f806e.js                                4.49 kB │ gzip:   1.97 kB
dist/assets/Storages-841978ca.js                            4.84 kB │ gzip:   1.65 kB
dist/assets/icon-a8771f42.js                                5.00 kB │ gzip:   2.41 kB
dist/assets/indexes-3793351f.js                             5.19 kB │ gzip:   1.80 kB
dist/assets/Other-1a10c331.js                               5.45 kB │ gzip:   1.39 kB
dist/assets/backup-restore-4d8636d3.js                      5.50 kB │ gzip:   2.23 kB
dist/assets/AddOrEdit-020db05b.js                           5.51 kB │ gzip:   1.80 kB
dist/assets/Profile-c3f27c8c.js                             6.00 kB │ gzip:   2.13 kB
dist/assets/archive-40a859be.js                             6.62 kB │ gzip:   2.80 kB
dist/assets/aliyun_video-04d8dfbd.js                        6.81 kB │ gzip:   2.84 kB
dist/assets/style-ce589a53.js                               7.33 kB │ gzip:   2.86 kB
dist/assets/index-a0a45662.js                               8.25 kB │ gzip:   3.31 kB
dist/assets/PackageDownload-d07e4dce.js                     9.29 kB │ gzip:   3.98 kB
dist/assets/index-4a0798e9.js                              11.17 kB │ gzip:   3.51 kB
dist/assets/text-editor-d1f04eb8.js                        11.76 kB │ gzip:   4.44 kB
dist/assets/helper-6098fe48.js                             13.02 kB │ gzip:   4.21 kB
dist/assets/index-1f561709.js                              13.84 kB │ gzip:   3.68 kB
dist/assets/helper-3180809b.js                             14.62 kB │ gzip:   5.28 kB
dist/assets/File-5916abcc.js                               33.96 kB │ gzip:  12.24 kB
dist/assets/entry-84a659a3.js                              36.49 kB │ gzip:  16.49 kB
dist/assets/Upload-7f1cdb7f.js                             38.04 kB │ gzip:  15.17 kB
dist/assets/Layout-36f9c37e.js                             46.77 kB │ gzip:  14.77 kB
dist/assets/entry-546b5c5d.js                              48.57 kB │ gzip:  14.31 kB
dist/assets/audio-b68830df.js                              61.06 kB │ gzip:  15.45 kB
dist/assets/index-bdb5b2ea.js                              69.87 kB │ gzip:  26.12 kB
dist/assets/video360-74fbbcf8.js                          109.44 kB │ gzip:  30.57 kB
dist/assets/Folder-45de8134.js                            119.24 kB │ gzip:  31.69 kB
dist/assets/video_box-fb9b3bb8.js                         159.65 kB │ gzip:  40.97 kB
dist/assets/asciinema-ec93cff5.js                         159.79 kB │ gzip:  64.50 kB
dist/assets/video-00b8064e.js                             279.46 kB │ gzip:  66.18 kB
dist/assets/hls-203db15a.js                               571.13 kB │ gzip: 175.27 kB
dist/assets/index-9a0bf3ce.js                           1,211.09 kB │ gzip: 367.91 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 55.52s
```


After:

```powershell
D:\temp\alist-web [md +1 ~3 -0 !]> pnpm build

> alist-web@0.0.0 build D:\temp\alist-web
> vite build

vite v4.5.13 building for production...
✓ 884 modules transformed.
[plugin:vite:reporter] 
(!) D:/temp/alist-web/src/pages/home/previews/download.tsx is dynamically imported by D:/temp/alist-web/src/pages/home/previews/index.ts but also statically imported by D:/temp/alist-web/src/pages/home/file/File.tsx, dynamic import will not move module into another chunk.

dist/assets/item_type-legacy.1b6076a1.js                           0.22 kB │ gzip:   0.17 kB
dist/assets/Wether-legacy.c5b1ea43.js                              0.32 kB │ gzip:   0.23 kB
dist/assets/ResponsiveGrid-legacy.bea9773d.js                      0.38 kB │ gzip:   0.29 kB
dist/assets/index-legacy.f7eaf338.js                               0.40 kB │ gzip:   0.26 kB
dist/assets/Decompress-legacy.6447e81c.js                          0.63 kB │ gzip:   0.37 kB
dist/assets/offline_download-legacy.2cb6eff2.js                    0.65 kB │ gzip:   0.38 kB
dist/assets/useTitle-legacy.373b0c3f.js                            0.69 kB │ gzip:   0.40 kB
dist/assets/Upload-legacy.0239a52e.js                              0.71 kB │ gzip:   0.44 kB
dist/assets/DeletePopover-legacy.c0203c97.js                       0.79 kB │ gzip:   0.39 kB
dist/assets/Copy-legacy.a8002a82.js                                0.88 kB │ gzip:   0.50 kB
dist/assets/index-legacy.e063d368.js                               0.95 kB │ gzip:   0.48 kB
dist/assets/Password-legacy.531fd459.js                            1.07 kB │ gzip:   0.56 kB
dist/assets/image-legacy.dbc6f17d.js                               1.16 kB │ gzip:   0.61 kB
dist/assets/Grid-legacy.1ea18d57.js                                1.18 kB │ gzip:   0.62 kB
dist/assets/ImageWithError-legacy.03e42bef.js                      1.35 kB │ gzip:   0.77 kB
dist/assets/markdown_with_word_wrap-legacy.4f9f0740.js             1.38 kB │ gzip:   0.78 kB
dist/assets/markdown-legacy.95c0ce48.js                            1.41 kB │ gzip:   0.79 kB
dist/assets/html-legacy.f829c994.js                                1.77 kB │ gzip:   0.96 kB
dist/assets/plist-legacy.8fa2ac87.js                               1.79 kB │ gzip:   0.97 kB
dist/assets/url-legacy.4e4bfcae.js                                 1.87 kB │ gzip:   0.99 kB
dist/assets/ipa-legacy.4d787694.js                                 2.25 kB │ gzip:   1.15 kB
dist/assets/SettingItem-legacy.2091c546.js                         3.52 kB │ gzip:   1.27 kB
dist/assets/GridItem-legacy.271f5f02.js                            3.68 kB │ gzip:   1.64 kB
dist/assets/Paginator-legacy.c51c87a7.js                           3.83 kB │ gzip:   1.51 kB
dist/assets/index-legacy.eac33cf8.js                               3.98 kB │ gzip:   0.67 kB
dist/assets/Images-legacy.86616596.js                              4.23 kB │ gzip:   1.84 kB
dist/assets/icon-legacy.dbc54534.js                                6.24 kB │ gzip:   3.09 kB
dist/assets/index-legacy.a46662bc.js                               6.55 kB │ gzip:   2.42 kB
dist/assets/List-legacy.299883e1.js                                6.75 kB │ gzip:   2.87 kB
dist/assets/About-legacy.62ff7456.js                               8.89 kB │ gzip:   3.39 kB
dist/assets/aliyun_office-legacy.8758463d.js                       8.97 kB │ gzip:   3.47 kB
dist/assets/Messenger-legacy.a5a1dc66.js                          10.22 kB │ gzip:   3.85 kB
dist/assets/Common-legacy.c2c601eb.js                             10.43 kB │ gzip:   3.96 kB
dist/assets/Metas-legacy.f0a00382.js                              10.64 kB │ gzip:   3.99 kB
dist/assets/2fa-legacy.12cd7739.js                                10.91 kB │ gzip:   4.06 kB
dist/assets/index-legacy.5b90e4a0.js                              11.16 kB │ gzip:   3.48 kB
dist/assets/webauthn-json.browser-ponyfill-legacy.1eb8248a.js     11.84 kB │ gzip:   4.21 kB
dist/assets/Users-legacy.f8a9e42c.js                              11.86 kB │ gzip:   4.30 kB
dist/assets/AddOrEdit-legacy.54bc9857.js                          12.23 kB │ gzip:   4.45 kB
dist/assets/AddOrEdit-legacy.e7013172.js                          12.41 kB │ gzip:   4.51 kB
dist/assets/FolderTree-legacy.7ba23075.js                         13.22 kB │ gzip:   4.91 kB
dist/assets/PublicKeys-legacy.726940ba.js                         13.23 kB │ gzip:   4.62 kB
dist/assets/Storages-legacy.ddc2cc3e.js                           14.57 kB │ gzip:   4.95 kB
dist/assets/indexes-legacy.ccd77e81.js                            14.86 kB │ gzip:   5.08 kB
dist/assets/style-legacy.ceb3bbcf.js                              14.92 kB │ gzip:   4.77 kB
dist/assets/S3-legacy.aeb29f5e.js                                 15.44 kB │ gzip:   5.27 kB
dist/assets/aliyun_video-legacy.855daa1e.js                       16.15 kB │ gzip:   6.09 kB
dist/assets/Other-legacy.8689b5ae.js                              16.58 kB │ gzip:   4.84 kB
dist/assets/AddOrEdit-legacy.321cc0ee.js                          16.64 kB │ gzip:   5.46 kB
dist/assets/Profile-legacy.e15d2707.js                            16.72 kB │ gzip:   5.75 kB
dist/assets/archive-legacy.1cc388fe.js                            17.54 kB │ gzip:   6.52 kB
dist/assets/backup-restore-legacy.da299605.js                     18.02 kB │ gzip:   6.11 kB
dist/assets/index-legacy.facc8281.js                              18.51 kB │ gzip:   6.74 kB
dist/assets/index-legacy.1c089a6e.js                              19.90 kB │ gzip:   6.60 kB
dist/assets/PackageDownload-legacy.19d0545d.js                    20.59 kB │ gzip:   7.54 kB
dist/assets/text-editor-legacy.0e7585ab.js                        21.11 kB │ gzip:   7.10 kB
dist/assets/helper-legacy.f7365997.js                             22.53 kB │ gzip:   7.29 kB
dist/assets/helper-legacy.0fc77302.js                             26.40 kB │ gzip:   8.03 kB
dist/assets/File-legacy.fdd32370.js                               32.62 kB │ gzip:  12.25 kB
dist/assets/entry-legacy.78fef6b0.js                              34.67 kB │ gzip:  15.00 kB
dist/assets/entry-legacy.cde6e995.js                              46.74 kB │ gzip:  12.91 kB
dist/assets/Upload-legacy.160a9c33.js                             57.21 kB │ gzip:  20.44 kB
dist/assets/Layout-legacy.a6b1242b.js                             65.53 kB │ gzip:  19.42 kB
dist/assets/index-legacy.9f59bb07.js                              67.25 kB │ gzip:  25.84 kB
dist/assets/audio-legacy.7bfd0514.js                              75.38 kB │ gzip:  17.46 kB
dist/assets/polyfills-legacy.6c0bf5df.js                         125.75 kB │ gzip:  50.20 kB
dist/assets/video360-legacy.1800f2c2.js                          144.40 kB │ gzip:  38.24 kB
dist/assets/Folder-legacy.c0f958c6.js                            151.49 kB │ gzip:  41.72 kB
dist/assets/video_box-legacy.50c9c082.js                         188.34 kB │ gzip:  46.37 kB
dist/assets/asciinema-legacy.1b8964c3.js                         229.66 kB │ gzip:  77.24 kB
dist/assets/index-legacy.f34ed80a.js                             275.85 kB │ gzip:  79.89 kB
dist/assets/video-legacy.4a7138c5.js                             279.75 kB │ gzip:  65.06 kB
dist/assets/hls-legacy.8dd416a2.js                               628.56 kB │ gzip: 182.81 kB
dist/assets/index-legacy.eab9f6ed.js                           1,053.64 kB │ gzip: 305.20 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
[plugin:vite:reporter]
(!) D:/temp/alist-web/src/pages/home/previews/download.tsx is dynamically imported by D:/temp/alist-web/src/pages/home/previews/index.ts but also statically imported by D:/temp/alist-web/src/pages/home/file/File.tsx, dynamic import will not move module into another chunk.

dist/index.html                                             4.01 kB │ gzip:   1.52 kB
dist/assets/loading-298ad3ff.gif                            4.18 kB
dist/assets/lg-22b72ba5.ttf                                 4.76 kB
dist/assets/lg-fefc5c0d.woff                                4.83 kB
dist/assets/lg-f2fe1c00.svg                                12.83 kB │ gzip:   4.60 kB
dist/assets/subtitles-octopus-worker-f95f2186.js          399.69 kB
dist/assets/TimesNewRoman-d9fb32eb.ttf                    834.24 kB
dist/assets/subtitles-octopus-worker-62892886.wasm      2,305.84 kB
dist/assets/SourceHanSansCN-Bold-b5627435.woff2         5,002.93 kB
dist/assets/style-a6d16836.css                              4.31 kB │ gzip:   0.94 kB
dist/assets/video360-f0192288.css                          12.18 kB │ gzip:   3.02 kB
dist/assets/audio-43f4c02b.css                             13.47 kB │ gzip:   2.63 kB
dist/assets/index-c0564af7.css                             19.20 kB │ gzip:   4.25 kB
dist/assets/Folder-6ee8584f.css                            32.29 kB │ gzip:   8.06 kB
dist/assets/asciinema-53412307.css                         44.98 kB │ gzip:   6.60 kB
dist/assets/item_type-32dc6fdf.js                           0.14 kB │ gzip:   0.13 kB
dist/assets/Wether-6c1c1dcb.js                              0.22 kB │ gzip:   0.18 kB
dist/assets/ImageWithError-2e84893c.js                      0.24 kB │ gzip:   0.20 kB
dist/assets/index-230d1da0.js                               0.26 kB │ gzip:   0.20 kB
dist/assets/markdown_with_word_wrap-84e14367.js             0.27 kB │ gzip:   0.21 kB
dist/assets/ResponsiveGrid-8458a97d.js                      0.29 kB │ gzip:   0.24 kB
dist/assets/markdown-083bd43e.js                            0.30 kB │ gzip:   0.23 kB
dist/assets/About-37d2d81f.js                               0.39 kB │ gzip:   0.28 kB
dist/assets/Upload-fdccc5a4.js                              0.44 kB │ gzip:   0.31 kB
dist/assets/Decompress-ff49c34d.js                          0.49 kB │ gzip:   0.31 kB
dist/assets/aliyun_office-70df2ec4.js                       0.50 kB │ gzip:   0.35 kB
dist/assets/useTitle-b2a44fff.js                            0.51 kB │ gzip:   0.33 kB
dist/assets/offline_download-a32a5c48.js                    0.51 kB │ gzip:   0.32 kB
dist/assets/Copy-4fe94e7d.js                                0.55 kB │ gzip:   0.36 kB
dist/assets/plist-048c1dd9.js                               0.62 kB │ gzip:   0.38 kB
dist/assets/html-789af533.js                                0.64 kB │ gzip:   0.38 kB
dist/assets/DeletePopover-e6ee0a0f.js                       0.67 kB │ gzip:   0.33 kB
dist/assets/url-379a69d8.js                                 0.71 kB │ gzip:   0.41 kB
dist/assets/index-f469362b.js                               0.87 kB │ gzip:   0.43 kB
dist/assets/Password-f8b51f76.js                            0.93 kB │ gzip:   0.50 kB
dist/assets/image-ea46719d.js                               0.94 kB │ gzip:   0.54 kB
dist/assets/Grid-368c175b.js                                0.95 kB │ gzip:   0.55 kB
dist/assets/ipa-ca1163b3.js                                 1.02 kB │ gzip:   0.55 kB
dist/assets/2fa-7e85c819.js                                 1.31 kB │ gzip:   0.68 kB
dist/assets/Messenger-ef059269.js                           1.34 kB │ gzip:   0.69 kB
dist/assets/Common-214adab5.js                              1.35 kB │ gzip:   0.72 kB
dist/assets/Metas-31135887.js                               1.78 kB │ gzip:   0.77 kB
dist/assets/webauthn-json.browser-ponyfill-f2f06d6e.js      2.37 kB │ gzip:   0.99 kB
dist/assets/Paginator-9f32593b.js                           2.48 kB │ gzip:   0.90 kB
dist/assets/SettingItem-83fe9612.js                         2.56 kB │ gzip:   0.92 kB
dist/assets/GridItem-8fd2c1e3.js                            2.61 kB │ gzip:   1.25 kB
dist/assets/Users-9e30e5c4.js                               2.71 kB │ gzip:   1.06 kB
dist/assets/AddOrEdit-f1d755ed.js                           2.81 kB │ gzip:   1.12 kB
dist/assets/AddOrEdit-41a46b04.js                           3.12 kB │ gzip:   1.17 kB
dist/assets/Images-13da9782.js                              3.18 kB │ gzip:   1.45 kB
dist/assets/S3-07cee354.js                                  3.88 kB │ gzip:   1.51 kB
dist/assets/PublicKeys-3e38c62b.js                          3.89 kB │ gzip:   1.35 kB
dist/assets/index-d9749951.js                               3.89 kB │ gzip:   0.61 kB
dist/assets/FolderTree-1d18c39c.js                          4.01 kB │ gzip:   1.64 kB
dist/assets/List-8a98bd80.js                                4.49 kB │ gzip:   1.97 kB
dist/assets/Storages-efe55f25.js                            4.84 kB │ gzip:   1.65 kB
dist/assets/icon-14a73960.js                                5.00 kB │ gzip:   2.41 kB
dist/assets/indexes-6e322240.js                             5.19 kB │ gzip:   1.81 kB
dist/assets/Other-bf62cc2a.js                               5.45 kB │ gzip:   1.40 kB
dist/assets/backup-restore-6406b74b.js                      5.50 kB │ gzip:   2.24 kB
dist/assets/AddOrEdit-c1c1c4fd.js                           5.51 kB │ gzip:   1.80 kB
dist/assets/index-4663e99b.js                               5.76 kB │ gzip:   2.21 kB
dist/assets/Profile-6b3ef123.js                             6.00 kB │ gzip:   2.13 kB
dist/assets/archive-317bfd3c.js                             6.62 kB │ gzip:   2.81 kB
dist/assets/aliyun_video-3887f192.js                        6.81 kB │ gzip:   2.85 kB
dist/assets/style-a7a476d9.js                               7.32 kB │ gzip:   2.86 kB
dist/assets/index-469f05e8.js                               8.26 kB │ gzip:   3.32 kB
dist/assets/PackageDownload-193d2c72.js                     9.29 kB │ gzip:   3.98 kB
dist/assets/index-aa37cb64.js                              11.17 kB │ gzip:   3.51 kB
dist/assets/text-editor-4424eda6.js                        11.76 kB │ gzip:   4.45 kB
dist/assets/helper-e7077735.js                             13.02 kB │ gzip:   4.21 kB
dist/assets/index-575ab39c.js                              13.85 kB │ gzip:   3.69 kB
dist/assets/helper-563316b0.js                             14.62 kB │ gzip:   5.28 kB
dist/assets/File-b13a7f4b.js                               33.97 kB │ gzip:  12.25 kB
dist/assets/entry-d9f6e37f.js                              36.49 kB │ gzip:  16.49 kB
dist/assets/Upload-78376c25.js                             38.04 kB │ gzip:  15.16 kB
dist/assets/Layout-908da0ce.js                             46.78 kB │ gzip:  14.78 kB
dist/assets/entry-dd7c5028.js                              48.57 kB │ gzip:  14.31 kB
dist/assets/audio-2bd6e3c6.js                              61.06 kB │ gzip:  15.46 kB
dist/assets/index-473f8c83.js                              69.87 kB │ gzip:  26.12 kB
dist/assets/video360-5b74bb31.js                          109.44 kB │ gzip:  30.57 kB
dist/assets/Folder-d1a8c39d.js                            119.24 kB │ gzip:  31.71 kB
dist/assets/video_box-18a67b97.js                         159.65 kB │ gzip:  40.97 kB
dist/assets/asciinema-fc05ab09.js                         159.79 kB │ gzip:  64.50 kB
dist/assets/index-bd1e6a85.js                             266.29 kB │ gzip:  79.21 kB
dist/assets/video-9674c135.js                             279.46 kB │ gzip:  66.19 kB
dist/assets/hls-ef7b5008.js                               571.13 kB │ gzip: 175.27 kB
dist/assets/index-7dd431d0.js                             937.61 kB │ gzip: 286.98 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 47.22s
```

