### PR TITLE
feat(storages): hide driver fields by show_when and link URLs in tips

### DIFF
--- a/src/lang/en/drivers.json
+++ b/src/lang/en/drivers.json
@@ -67,9 +67,9 @@
   },
   "123 Open": {
     "access_token": "Access token",
-    "access_token-tips": "Required in token mode. Refreshed automatically when a refresh_token and client credentials are present.",
+    "access_token-tips": "Get it at https://alistgo.com/zh/tool/123pan/request.html",
     "auth_mode": "Auth mode",
-    "auth_mode-tips": "client_credentials: fill in your own clientID/clientSecret applied on the open platform. token: fill in the access_token (and refresh_token) obtained from an onboarded enterprise's app.",
+    "auth_mode-tips": "token: use the access_token/refresh_token, no developer application needed. client_credentials: use the clientID/clientSecret of your own application on the open platform.",
     "auth_modes": {
       "client_credentials": "Client credentials",
       "token": "Token"
@@ -79,7 +79,7 @@
     "private_key": "Private key",
     "private_key-tips": "Direct link signing key. Leave empty to return unsigned links.",
     "refresh_token": "Refresh token",
-    "refresh_token-tips": "Optional. Single-use and rotated on every refresh; the new value is saved back automatically.",
+    "refresh_token-tips": "Obtained together with the access_token. Single-use and rotated on every refresh; the new value is saved back automatically.",
     "root_folder_id": "Root folder id",
     "uid": "Uid",
     "uid-tips": "User ID used by direct link signing.",

--- a/src/pages/manage/storages/AddOrEdit.tsx
+++ b/src/pages/manage/storages/AddOrEdit.tsx
@@ -43,6 +43,30 @@ function GetDefaultValue(type: Type, value?: string) {
 
 type Drivers = Record<string, DriverInfo>
 
+// show_when: "field=a|b" — the item is shown only when the referenced field
+// currently equals one of the listed values. Unset fields fall back to the
+// referenced item's default.
+export function isItemVisible(
+  item: DriverItem,
+  values: Record<string, any>,
+  items: DriverItem[],
+): boolean {
+  const cond = item.show_when?.trim()
+  if (!cond) return true
+  const eq = cond.indexOf("=")
+  if (eq < 0) return true
+  const field = cond.slice(0, eq).trim()
+  const allowed = cond
+    .slice(eq + 1)
+    .split("|")
+    .map((v) => v.trim())
+  let current = values[field]
+  if (current === undefined || current === null || current === "") {
+    current = items.find((i) => i.name === field)?.default ?? ""
+  }
+  return allowed.includes(String(current))
+}
+
 const AddOrEdit = () => {
   const t = useT()
   const { params, back, to } = useRouter()
@@ -176,15 +200,23 @@ const AddOrEdit = () => {
           </For>
           <For each={drivers()[storage.driver].additional}>
             {(item) => (
-              <Item
-                {...item}
-                driver={storage.driver}
-                additionValues={addition}
-                value={addition[item.name] as any}
-                onChange={(val: any) => {
-                  setAddition(item.name, val)
-                }}
-              />
+              <Show
+                when={isItemVisible(
+                  item,
+                  addition,
+                  drivers()[storage.driver].additional,
+                )}
+              >
+                <Item
+                  {...item}
+                  driver={storage.driver}
+                  additionValues={addition}
+                  value={addition[item.name] as any}
+                  onChange={(val: any) => {
+                    setAddition(item.name, val)
+                  }}
+                />
+              </Show>
             )}
           </For>
         </Show>

--- a/src/pages/manage/storages/Item.tsx
+++ b/src/pages/manage/storages/Item.tsx
@@ -1,4 +1,5 @@
 import {
+  Anchor,
   Button,
   Center,
   FormControl,
@@ -52,6 +53,33 @@ export type ItemProps = DriverItem & {
         value: string
       }
   )
+
+// trailing punctuation stays outside the link
+const urlPattern = /(https?:\/\/[^\s<>"')]*[^\s<>"'),.;:])/g
+
+// Renders help text with bare URLs turned into links.
+const HelpText = (props: { text: string }) => {
+  const parts = () => props.text.split(urlPattern)
+  return (
+    <For each={parts()}>
+      {(part) =>
+        /^https?:\/\//.test(part) ? (
+          <Anchor
+            href={part}
+            external
+            p="0"
+            color="$info9"
+            wordBreak="break-all"
+          >
+            {part}
+          </Anchor>
+        ) : (
+          part
+        )
+      }
+    </For>
+  )
+}
 
 const Item = (props: ItemProps) => {
   const t = useT()
@@ -320,11 +348,13 @@ const Item = (props: ItemProps) => {
       </Switch>
       <Show when={props.help}>
         <FormHelperText>
-          {t(
-            props.driver === "common"
-              ? `storages.common.${props.name}-tips`
-              : `drivers.${props.driver}.${props.name}-tips`,
-          )}
+          <HelpText
+            text={t(
+              props.driver === "common"
+                ? `storages.common.${props.name}-tips`
+                : `drivers.${props.driver}.${props.name}-tips`,
+            )}
+          />
         </FormHelperText>
       </Show>
       <Show when={isChunkSizeField}>

--- a/src/types/driver_item.ts
+++ b/src/types/driver_item.ts
@@ -7,6 +7,8 @@ export interface DriverItem {
   options: string
   required?: boolean
   help?: string
+  // e.g. "auth_mode=token" or "auth_mode=token|client_credentials"
+  show_when?: string
 }
 
 export interface DriverConfig {


### PR DESCRIPTION
## Summary

- `DriverItem` gains `show_when` (`"field=a|b"`). The add/edit storage form only renders an additional item while the referenced field equals one of the listed values; unset fields fall back to that item's default.
- Help text: bare URLs are rendered as clickable links (opens in a new tab).
- 123 Open tips updated for the token-first auth mode, linking to https://alistgo.com/zh/tool/123pan/request.html

Backend counterpart: AlistGo/alist#9647 (adds the `show_when` tag and the 123 Open changes).

## Test plan

- [x] Prettier and `tsc --noEmit` (no new errors)
- [x] Manually verified against the backend PR: default Token shows only access/refresh token; switching to Client credentials shows only clientID/clientSecret; editing an existing storage respects the stored mode; links render and open.