### PR TITLE
fix(preview): respect preview_archives_by_default and add bulk enable/disable in preview management

### DIFF
--- a/src/lang/en/preview_settings.json
+++ b/src/lang/en/preview_settings.json
@@ -2,6 +2,12 @@
   "add_extension": "Add extension",
   "add_iframe": "Add iframe previewer",
   "copy_to_extensions": "Copy settings to...",
+  "disable_all": "Disable all",
+  "enable_all": "Enable all",
+  "disable_all_confirm": "Disable every preview for all extensions?",
+  "enable_all_confirm": "Enable every preview for all extensions?",
+  "disable_current": "Disable all for this extension",
+  "enable_current": "Enable all for this extension",
   "source": {
     "builtin": "built-in",
     "iframe": "iframe",

--- a/src/pages/home/previews/index.ts
+++ b/src/pages/home/previews/index.ts
@@ -268,6 +268,19 @@ export const getPreviews = (file: PreviewFile): PreviewComponent[] => {
     })
   })
 
+  // Download sits after prior built-ins and iframe previews but before
+  // non-prior built-ins (e.g. Archive when preview_archives_by_default is
+  // off), so those never become the default unless explicitly ordered.
+  if (!isShareRoute || file.download_url) {
+    candidates.push({
+      id: "download",
+      name: "Download",
+      i18nKey: "home.preview.download",
+      component: lazy(() => import("./download")),
+      defaultRank: 5000,
+    })
+  }
+
   candidates.sort((a, b) => {
     const ai = orderIndex.has(a.id)
       ? orderIndex.get(a.id)!
@@ -279,18 +292,7 @@ export const getPreviews = (file: PreviewFile): PreviewComponent[] => {
     return a.defaultRank - b.defaultRank
   })
 
-  const res: PreviewComponent[] = candidates.map(
-    ({ id, defaultRank, ...rest }) => rest,
-  )
-
-  if (!isShareRoute || file.download_url) {
-    res.push({
-      name: "Download",
-      i18nKey: "home.preview.download",
-      component: lazy(() => import("./download")),
-    })
-  }
-  return res
+  return candidates.map(({ id, defaultRank, ...rest }) => rest)
 }
 
 export const getBuiltinPreviewRegistry = (): readonly Readonly<Preview>[] =>

--- a/src/pages/manage/preview-settings/ExtensionPicker.tsx
+++ b/src/pages/manage/preview-settings/ExtensionPicker.tsx
@@ -14,8 +14,9 @@ import {
   SelectValue,
 } from "@hope-ui/solid"
 import { createMemo, createSignal, For, Show } from "solid-js"
-import { getSetting } from "~/store"
+import { getPreviewSettings, getSetting } from "~/store"
 import { useT } from "~/hooks"
+import { previewSettingsVersion } from "./store"
 
 const COMMON_EXTS = [
   "pdf",
@@ -83,6 +84,8 @@ export const useExtensionList = (extraKeys: () => string[]) =>
     collectKeysFromRecord(getSetting("external_previews")).forEach((k) =>
       set.add(k),
     )
+    previewSettingsVersion()
+    Object.keys(getPreviewSettings()).forEach((k) => set.add(k))
     extraKeys().forEach((k) => set.add(k.toLowerCase()))
     return Array.from(set).sort()
   })

--- a/src/pages/manage/preview-settings/index.tsx
+++ b/src/pages/manage/preview-settings/index.tsx
@@ -27,6 +27,8 @@ import {
   deleteIframeEntry,
   previewSettingsVersion,
   reorderRow,
+  setAllForExtension,
+  setAllForExtensions,
   toggleRow,
   upsertIframeEntry,
 } from "./store"
@@ -45,6 +47,7 @@ const PreviewSettings = () => {
   const [editing, setEditing] = createSignal<EditDraft | null>(null)
   const [copying, setCopying] = createSignal(false)
   const [copyTargets, setCopyTargets] = createSignal<Set<string>>(new Set())
+  const [bulk, setBulk] = createSignal<"enable" | "disable" | null>(null)
   const extList = useExtensionList(userExts)
   const toggleTarget = (e: string) => {
     const next = new Set(copyTargets())
@@ -102,6 +105,17 @@ const PreviewSettings = () => {
         >
           {t("preview_settings.copy_to_extensions")}
         </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          colorScheme="danger"
+          onClick={() => setBulk("disable")}
+        >
+          {t("preview_settings.disable_all")}
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setBulk("enable")}>
+          {t("preview_settings.enable_all")}
+        </Button>
       </HStack>
       <VStack w="$full" alignItems="stretch" spacing="$2">
         <For each={rows()}>
@@ -123,11 +137,63 @@ const PreviewSettings = () => {
           )}
         </For>
       </VStack>
-      <HStack>
+      <HStack spacing="$2">
         <Button size="sm" onClick={openAdd}>
           {t("preview_settings.add_iframe")}
         </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setAllForExtension(ext(), false).catch(reportError)}
+        >
+          {t("preview_settings.disable_current")}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setAllForExtension(ext(), true).catch(reportError)}
+        >
+          {t("preview_settings.enable_current")}
+        </Button>
       </HStack>
+
+      <Modal opened={!!bulk()} onClose={() => setBulk(null)}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader>
+            {t(
+              bulk() === "disable"
+                ? "preview_settings.disable_all"
+                : "preview_settings.enable_all",
+            )}
+          </ModalHeader>
+          <ModalBody>
+            {t(
+              bulk() === "disable"
+                ? "preview_settings.disable_all_confirm"
+                : "preview_settings.enable_all_confirm",
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              colorScheme={bulk() === "disable" ? "danger" : "primary"}
+              onClick={async () => {
+                const mode = bulk()
+                if (!mode) return
+                try {
+                  await setAllForExtensions(extList(), mode === "enable")
+                  setBulk(null)
+                } catch (e) {
+                  reportError(e)
+                }
+              }}
+            >
+              {t("global.ok")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
 
       <Modal opened={!!editing()} onClose={() => setEditing(null)}>
         <ModalOverlay />

--- a/src/pages/manage/preview-settings/index.tsx
+++ b/src/pages/manage/preview-settings/index.tsx
@@ -25,6 +25,7 @@ import {
   buildRowsForExtension,
   copyExtensionConfigTo,
   deleteIframeEntry,
+  loadTypeSettings,
   previewSettingsVersion,
   reorderRow,
   setAllForExtension,
@@ -63,6 +64,7 @@ const PreviewSettings = () => {
 
   const reportError = (e: unknown) =>
     notify.error(e instanceof Error ? e.message : String(e))
+  loadTypeSettings().catch(reportError)
 
   const openAdd = () => setEditing({ name: "", url: "" })
   const openEdit = (name: string, url?: string) =>

--- a/src/pages/manage/preview-settings/store.ts
+++ b/src/pages/manage/preview-settings/store.ts
@@ -7,7 +7,7 @@ import {
   type PreviewSettingsMap,
 } from "~/store"
 import type { PreviewOverride } from "~/store/settings"
-import { ObjType } from "~/types"
+import { Group, ObjType, type SettingItem } from "~/types"
 import {
   handleRespWithoutAuth,
   handleRespWithoutAuthAndNotify,
@@ -68,13 +68,33 @@ const typeSettingKey = (type?: ObjType): string | null => {
   }
 }
 
+// video_types/audio_types/image_types/text_types are PRIVATE settings and
+// absent from /public/settings, so the admin page loads them itself.
+const [typeSettings, setTypeSettings] = createSignal<Record<string, string>>({})
+
+export const loadTypeSettings = async (): Promise<void> => {
+  const resp = (await r.get(`/admin/setting/list?group=${Group.PREVIEW}`)) as {
+    code: number
+    data: SettingItem[]
+    message: string
+  }
+  handleRespWithoutAuthAndNotify(resp, (data) => {
+    const next: Record<string, string> = {}
+    data
+      .filter((i) => i.key.endsWith("_types"))
+      .forEach((i) => (next[i.key] = i.value))
+    setTypeSettings(next)
+    bumpPreviewSettingsVersion((v) => v + 1)
+  })
+}
+
 const typeMatchesExtension = (
   type: ObjType | undefined,
   ext: string,
 ): boolean => {
   const key = typeSettingKey(type)
   if (!key) return false
-  return getSetting(key)
+  return (typeSettings()[key] ?? getSetting(key))
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean)

--- a/src/pages/manage/preview-settings/store.ts
+++ b/src/pages/manage/preview-settings/store.ts
@@ -199,20 +199,8 @@ const normaliseOverride = (o: PreviewOverride): PreviewOverride | undefined => {
   return Object.keys(clean).length ? clean : undefined
 }
 
-export const updateOverride = async (
-  ext: string,
-  mutate: (current: PreviewOverride) => PreviewOverride,
-): Promise<void> => {
-  const lower = ext.toLowerCase()
-  const current: PreviewSettingsMap = { ...getPreviewSettings() }
-  const next = mutate({ ...(current[lower] ?? {}) })
-  const normalised = normaliseOverride(next)
-  if (normalised) {
-    current[lower] = normalised
-  } else {
-    delete current[lower]
-  }
-  const value = JSON.stringify(current)
+const writePreviewSettings = async (map: PreviewSettingsMap): Promise<void> => {
+  const value = JSON.stringify(map)
   await new Promise<void>((resolve, reject) => {
     r.post("/admin/setting/save", [
       { key: "preview_settings", value, type: "text", group: 3 },
@@ -228,6 +216,30 @@ export const updateOverride = async (
   })
 }
 
+const applyOverride = (
+  map: PreviewSettingsMap,
+  ext: string,
+  mutate: (current: PreviewOverride) => PreviewOverride,
+): void => {
+  const lower = ext.toLowerCase()
+  const next = mutate({ ...(map[lower] ?? {}) })
+  const normalised = normaliseOverride(next)
+  if (normalised) {
+    map[lower] = normalised
+  } else {
+    delete map[lower]
+  }
+}
+
+export const updateOverride = async (
+  ext: string,
+  mutate: (current: PreviewOverride) => PreviewOverride,
+): Promise<void> => {
+  const current: PreviewSettingsMap = { ...getPreviewSettings() }
+  applyOverride(current, ext, mutate)
+  await writePreviewSettings(current)
+}
+
 export const toggleRow = (ext: string, id: string, nextEnabled: boolean) =>
   updateOverride(ext, (cur) => {
     const disabled = new Set(cur.disabled ?? [])
@@ -238,6 +250,34 @@ export const toggleRow = (ext: string, id: string, nextEnabled: boolean) =>
 
 const computeDefaultOrder = (ext: string): string[] =>
   buildRowsForExtension(ext, undefined).map((r) => r.id)
+
+const setDisabledAll = (
+  ext: string,
+  enabled: boolean,
+): ((cur: PreviewOverride) => PreviewOverride) => {
+  return (cur) => ({
+    ...cur,
+    disabled: enabled ? [] : computeDefaultOrder(ext),
+  })
+}
+
+export const setAllForExtension = (ext: string, enabled: boolean) =>
+  updateOverride(ext, setDisabledAll(ext, enabled))
+
+export const setAllForExtensions = async (
+  exts: string[],
+  enabled: boolean,
+): Promise<void> => {
+  const current: PreviewSettingsMap = { ...getPreviewSettings() }
+  const targets = new Set<string>([
+    ...exts.map((e) => e.toLowerCase()),
+    ...Object.keys(current),
+  ])
+  targets.forEach((ext) => {
+    applyOverride(current, ext, setDisabledAll(ext, enabled))
+  })
+  await writePreviewSettings(current)
+}
 
 export const reorderRow = (
   ext: string,


### PR DESCRIPTION
## Problem

Since the per-extension preview management refactor, turning off **Preview archives by default** no longer works: archives still open in the archive previewer. The renderer appends Download after every candidate, so a non-default preview is only demoted below the other previews and still ends up ahead of Download. Admins had to disable the archive previewer per extension by hand.

The preview management page also never listed the built-in Video / Audio / Image / Text previewers, because `video_types` / `audio_types` / `image_types` / `text_types` are PRIVATE settings and are absent from `/public/settings`.

## Changes

- Download now takes a fixed rank between iframe previews and non-default built-ins, restoring the old behaviour. Explicit ordering from preview management still wins.
- Preview management gains bulk actions:
  - **Disable all / Enable all** for every listed extension, confirmed in a modal and saved in one request. Existing manual ordering is kept.
  - **Disable all / Enable all for this extension**.
- Extensions that already carry overrides are included in the extension picker so they stay reachable after a bulk disable.
- The page loads the preview settings group through the admin API so type-classified built-ins are matched and listed.

## Verification

Manually tested against a local v3 backend:

- Disable all → every listed extension written to `preview_settings`, archive files show only Download.
- Enable all → `preview_settings` back to `{}`.
- With no overrides and the setting off, archives default to Download with Archive Preview still selectable; with the setting on, Archive Preview is the default.
- `mp4` now lists Video and Video 360 and bulk disable covers them.

`prettier --check` and `vite build` pass.